### PR TITLE
Upgrade to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
         <!-- Use consistent language features and framework -->
         <LangVersion>latest</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Keystone.Cli/Application/GitHub/GitHubZipEntryProviderFactory.cs
+++ b/src/Keystone.Cli/Application/GitHub/GitHubZipEntryProviderFactory.cs
@@ -34,7 +34,7 @@ public class GitHubZipEntryProviderFactory(IHttpClientFactory httpClientFactory)
             }
             catch
             {
-                archive.Dispose();
+                await archive.DisposeAsync();
                 throw;
             }
         }

--- a/src/Keystone.Cli/Application/Utility/Text/TextFileUtility.cs
+++ b/src/Keystone.Cli/Application/Utility/Text/TextFileUtility.cs
@@ -21,12 +21,9 @@ public static class TextFileUtility
         using var reader = new StreamReader(stream, leaveOpen: true);
 
         var lines = ImmutableList.CreateBuilder<string>();
-        while (! reader.EndOfStream)
+        while (await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is { } line)
         {
-            if (await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is { } line)
-            {
-                lines.Add(line);
-            }
+            lines.Add(line);
         }
 
         return lines.ToImmutable();


### PR DESCRIPTION
This pull request includes several updates focused on upgrading the project to .NET 10, improving resource disposal practices, and simplifying stream reading logic.

**Platform and Framework Updates:**

* Upgraded the target framework from `net9.0` to `net10.0` in `Directory.Build.props` to ensure compatibility with the latest .NET features and improvements.

**Resource Management Improvements:**

* Replaced synchronous `Dispose()` with asynchronous `DisposeAsync()` for the `archive` object in `GitHubZipEntryProviderFactory.cs` to ensure proper asynchronous resource cleanup [VSTHRD103](https://microsoft.github.io/vs-threading/analyzers/VSTHRD103.html).

**Code Simplification and Efficiency:**

* Simplified the loop in `TextFileUtility.cs` by removing an unnecessary check for `EndOfStream` and relying solely on the result of `ReadLineAsync`, making the code more concise and idiomatic [CA2024](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2024).