### PR TITLE
Configure SSH for Git operations in tag release workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -13,10 +13,23 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # required to create/push tags reliably
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "10.0.x"
+
+      - name: Add github.com to known_hosts
+        shell: bash
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+
+      - name: Ensure origin uses SSH
+        shell: bash
+        run: |
+          git remote set-url origin git@github.com:Knight-Owl-Dev/keystone-cli.git
+          git remote -v
 
       - name: Read version from csproj
         id: v


### PR DESCRIPTION
This pull request updates the release workflow to support secure SSH-based git operations when tagging releases. The main improvements are focused on authentication and repository access.

**Workflow authentication and repository access:**

* Added the `ssh-key` input to the `actions/checkout@v4` step to enable SSH authentication using the `RELEASE_DEPLOY_KEY` secret.
* Added a step to add `github.com` to the `known_hosts` file to prevent SSH host verification issues during git operations.
* Added a step to ensure the `origin` remote uses the SSH URL, enabling tag creation and pushes over SSH.