### PR TITLE
Refine release workflow to compute checksums and format release body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,15 +106,16 @@ jobs:
           set -euo pipefail
 
           echo "Release assets:" 
-          files=$(find dist -maxdepth 3 -type f -name '*.tar.gz' -print)
+          (cd dist && find . -maxdepth 3 -type f -name '*.tar.gz' -print | sed 's|^\./||' | sort)
+
+          files=$(cd dist && find . -maxdepth 3 -type f -name '*.tar.gz' -print | sed 's|^\./||')
           if [[ -z "$files" ]]; then
             echo "ERROR: No .tar.gz files found under dist/" >&2
             exit 1
           fi
 
-          printf "%s\n" $files | sort
-
-          sha256sum $files | sort > checksums.txt
+          # Compute checksums from inside dist/ so the paths in checksums.txt don't include the dist/ prefix.
+          (cd dist && sha256sum $files) | sort > checksums.txt
 
           echo ""
           echo "checksums.txt:"
@@ -125,8 +126,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          cat > release-body.md <<'EOF'
-          Automated release for ${GITHUB_REF_NAME}.
+          cat > release-body.md <<EOF
+          Automated release for v${{ needs.validate.outputs.version }}.
 
           SHA256 checksums:
           ```


### PR DESCRIPTION
This pull request updates the release workflow to improve the accuracy and clarity of release asset handling and release notes. The main changes focus on ensuring the generated `checksums.txt` file contains the correct file paths and that the release notes use the precise version number.

**Release artifact handling:**

* Updated the logic for finding `.tar.gz` files and generating `checksums.txt` so that file paths in the checksum file no longer include the `dist/` prefix, making the checksums more portable and consistent. (`.github/workflows/release.yml`)

**Release notes generation:**

* Modified the release body template to use the actual version number from the workflow outputs, ensuring the release notes reference the correct version (e.g., `v1.2.3` instead of just the branch name). (`.github/workflows/release.yml`)