### PR TITLE
Bump version to `0.1.3` and update related documentation

### DIFF
--- a/docs/man/man1/keystone-cli.1
+++ b/docs/man/man1/keystone-cli.1
@@ -186,7 +186,7 @@ To switch a project at a specific path to use the `core` template:
 .Dl keystone-cli project switch-template --project-path /path/to/my-project core
 
 .Sh VERSION
-keystone-cli 0.1.2
+keystone-cli 0.1.3
 
 .Sh AUTHOR
 Knight Owl LLC

--- a/src/Keystone.Cli/Keystone.Cli.csproj
+++ b/src/Keystone.Cli/Keystone.Cli.csproj
@@ -12,11 +12,11 @@
         <Copyright>© 2025 Knight Owl LLC. All rights reserved.</Copyright>
         <Description>A command-line interface for Keystone.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>0.1.2</Version>
-        <ApplicationVersion>0.1.2</ApplicationVersion>
-        <AssemblyVersion>0.1.2</AssemblyVersion>
-        <FileVersion>0.1.2</FileVersion>
-        <InformationalVersion>0.1.2</InformationalVersion>
+        <Version>0.1.3</Version>
+        <ApplicationVersion>0.1.3</ApplicationVersion>
+        <AssemblyVersion>0.1.3</AssemblyVersion>
+        <FileVersion>0.1.3</FileVersion>
+        <InformationalVersion>0.1.3</InformationalVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/tests/Keystone.Cli.UnitTests/Application/Commands/Info/InfoCommandTests.cs
+++ b/tests/Keystone.Cli.UnitTests/Application/Commands/Info/InfoCommandTests.cs
@@ -33,7 +33,7 @@ public class InfoCommandTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(actual.Version, Does.StartWith("0.1.2"));
+            Assert.That(actual.Version, Does.StartWith("0.1.3"));
             Assert.That(actual.Description, Is.EqualTo("A command-line interface for Keystone."));
             Assert.That(actual.Copyright, Is.EqualTo("© 2025 Knight Owl LLC. All rights reserved."));
             Assert.That(actual.DefaultTemplateTarget, Is.EqualTo(defaultTemplateTarget));


### PR DESCRIPTION
This pull request updates the version of the Keystone CLI from 0.1.2 to 0.1.3 throughout the codebase and documentation. The changes ensure consistency across project files and unit tests.

Version update:

* Updated the version number from `0.1.2` to `0.1.3` in the project file `Keystone.Cli.csproj`, affecting all related version fields.
* Updated the displayed version in the man page documentation (`keystone-cli.1`) from `0.1.2` to `0.1.3`.

Testing:

* Updated the unit test in `InfoCommandTests.cs` to check for the new version prefix `0.1.3` instead of `0.1.2`.