### PR TITLE
Align branch naming guidelines with GitHub issue based branch defaults

### DIFF
--- a/docs/how-to/how-to-workflow.md
+++ b/docs/how-to/how-to-workflow.md
@@ -24,12 +24,15 @@ Issues act as lightweight tickets and historical context.
 
 ### 2. Working on an Issue
 
-- Create a branch using GitHub's **Create a branch** link on the issue page
+- Create a branch for the work
+    - **Collaborators**: Use GitHub's **Create a branch** link on the issue page
+    - **External contributors**: Create a branch in your fork following the same naming pattern
 - Implement the change
 - Commit freely during development
 
 GitHub generates branch names in the format `<issue-number>-<issue-title-slug>`
-(e.g., `42-fix-login-bug`). Using this default ensures consistency and avoids manual naming.
+(e.g., `42-fix-login-bug`). Following this pattern ensures consistency whether the branch
+is created automatically or manually.
 
 ### 3. Opening a Pull Request
 


### PR DESCRIPTION
## Summary

Align the project’s branch naming guidelines with GitHub’s default branch naming when creating branches directly from issues.

## Related Issues

Refs #26

## Changes

- Updated branch naming guidelines to align with GitHub's default format
- Clarified branch creation instructions for collaborators and external contributors