### PR TITLE
Bump version to 0.1.6

### DIFF
--- a/docs/man/man1/keystone-cli.1
+++ b/docs/man/man1/keystone-cli.1
@@ -1,4 +1,4 @@
-.Dd August 2025
+.Dd January 2026
 .Dt KEYSTONE-CLI 1
 .Os
 
@@ -186,7 +186,7 @@ To switch a project at a specific path to use the `core` template:
 .Dl keystone-cli project switch-template --project-path /path/to/my-project core
 
 .Sh VERSION
-keystone-cli 0.1.5
+keystone-cli 0.1.6
 
 .Sh AUTHOR
 Knight Owl LLC

--- a/src/Keystone.Cli/Keystone.Cli.csproj
+++ b/src/Keystone.Cli/Keystone.Cli.csproj
@@ -12,11 +12,11 @@
         <Copyright>© 2025 Knight Owl LLC. All rights reserved.</Copyright>
         <Description>A command-line interface for Keystone.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>0.1.5</Version>
-        <ApplicationVersion>0.1.5</ApplicationVersion>
-        <AssemblyVersion>0.1.5</AssemblyVersion>
-        <FileVersion>0.1.5</FileVersion>
-        <InformationalVersion>0.1.5</InformationalVersion>
+        <Version>0.1.6</Version>
+        <ApplicationVersion>0.1.6</ApplicationVersion>
+        <AssemblyVersion>0.1.6</AssemblyVersion>
+        <FileVersion>0.1.6</FileVersion>
+        <InformationalVersion>0.1.6</InformationalVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/tests/Keystone.Cli.UnitTests/Application/Commands/Info/InfoCommandTests.cs
+++ b/tests/Keystone.Cli.UnitTests/Application/Commands/Info/InfoCommandTests.cs
@@ -33,7 +33,7 @@ public class InfoCommandTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(actual.Version, Does.StartWith("0.1.5"));
+            Assert.That(actual.Version, Does.StartWith("0.1.6"));
             Assert.That(actual.Description, Is.EqualTo("A command-line interface for Keystone."));
             Assert.That(actual.Copyright, Is.EqualTo("© 2025 Knight Owl LLC. All rights reserved."));
             Assert.That(actual.DefaultTemplateTarget, Is.EqualTo(defaultTemplateTarget));


### PR DESCRIPTION
## Summary

Prepares the project for the next release by incrementing the version number to 0.1.6 across all configuration files.

## Changes

- Update version properties in `Keystone.Cli.csproj` (Version, ApplicationVersion, AssemblyVersion, FileVersion, InformationalVersion)
- Update man page date to January 2026 and version to 0.1.6
- Update version assertion in unit tests