### PR TITLE
Add automatic `dependencies` label to Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
     groups:
       minor-and-patch:
         update-types:
@@ -18,6 +20,8 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
## Summary

Configure Dependabot to automatically apply the `dependencies` label to PRs it creates, ensuring consistent labeling and proper release notes categorization without manual intervention.

## Related Issues

Fixes #44

## Changes

- Add `labels` configuration to both NuGet and GitHub Actions ecosystems in `dependabot.yml`