### PR TITLE
Add ecosystem-specific labels to Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+      - ".NET"
     groups:
       minor-and-patch:
         update-types:
@@ -22,6 +23,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+      - "github-actions"
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
## Summary

Enhance Dependabot configuration to apply ecosystem-specific labels in addition to the existing `dependencies` label, making it easier to filter and identify the type of dependency updates at a glance.

## Related Issues

Fixes #46

## Changes

- Add `.NET` label to NuGet ecosystem configuration
- Add `github-actions` label to GitHub Actions ecosystem configuration

## Further Comments

Requires creating the `.NET` and `github-actions` labels in the repository if they don't already exist.