### PR TITLE
Include LICENSE file in release tarballs

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -95,6 +95,7 @@ package() {
     -czf "$ARCHIVE" \
     keystone-cli \
     appsettings.json \
+    -C "$REPO_ROOT" LICENSE \
     -C "$REPO_ROOT/docs/man/man1" keystone-cli.1
 
   if command -v shasum >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Ensures MIT license compliance by including the LICENSE file in release tarballs. This is required for proper distribution via Homebrew and apt, as the MIT license mandates that the copyright notice and permission notice be included with all copies of the software.

## Related Issues

Fixes #51

## Changes

- Updated `scripts/package-release.sh` to include LICENSE in the tarball alongside the binary, config, and man page