### PR TITLE
Document .Dd tag update in release how-to guide

### DIFF
--- a/docs/how-to/how-to-release.md
+++ b/docs/how-to/how-to-release.md
@@ -38,7 +38,7 @@ This displays the current version from `Keystone.Cli.csproj`.
 This updates the version in all required files:
 
 - `src/Keystone.Cli/Keystone.Cli.csproj` (all five version properties)
-- `docs/man/man1/keystone-cli.1` (VERSION section)
+- `docs/man/man1/keystone-cli.1` (`.Dd` document date and VERSION section)
 - `tests/Keystone.Cli.UnitTests/Application/Commands/Info/InfoCommandTests.cs` (version assertion)
 
 The version must follow semantic versioning format (`X.Y.Z`).


### PR DESCRIPTION
## Summary

Clarifies the release documentation to specify that the `/version` command updates both the `.Dd` document date and the VERSION section in the man page, making the documented scope of version updates accurate.

## Related Issues

Fixes #53

## Changes

- Update `docs/how-to/how-to-release.md` to mention the `.Dd` document date alongside the VERSION section