### PR TITLE
Fix checksums.txt to use standard checksum-first format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,9 +118,9 @@ jobs:
             exit 1
           fi
 
-          # Compute checksums: format is "filename  checksum" (filename first, stripped of artifact directory)
+          # Compute checksums: standard GNU coreutils format (checksum first, compatible with sha256sum -c)
           (cd dist && sha256sum $files) | while read sum file; do
-            echo "$(basename "$file")  $sum"
+            echo "$sum  $(basename "$file")"
           done | sort > checksums.txt
 
           echo ""


### PR DESCRIPTION
## Summary

Enables users to verify release downloads using standard tools like `sha256sum -c checksums.txt`. The previous format placed filenames before checksums, which is incompatible with verification utilities.

## Related Issues

Fixes #55

## Changes

- Swap checksum output order from `filename  checksum` to `checksum  filename` in the release workflow
- Update comment to document the standard GNU coreutils format