### PR TITLE
Add `.deb` package building to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,29 @@ jobs:
           path: artifacts/release/keystone-cli_${{ needs.validate.outputs.version }}_${{ matrix.rid }}.tar.gz
           if-no-files-found: error
 
+      - name: Setup Go
+        if: startsWith(matrix.rid, 'linux-')
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Install nfpm
+        if: startsWith(matrix.rid, 'linux-')
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+
+      - name: Build .deb package (${{ matrix.rid }})
+        if: startsWith(matrix.rid, 'linux-')
+        shell: bash
+        run: bash ./scripts/package-deb.sh "${{ needs.validate.outputs.version }}" "${{ matrix.rid }}"
+
+      - name: Upload .deb artifact
+        if: startsWith(matrix.rid, 'linux-')
+        uses: actions/upload-artifact@v6
+        with:
+          name: deb-${{ matrix.rid }}
+          path: artifacts/release/keystone-cli_*.deb
+          if-no-files-found: error
+
   publish-release:
     name: Publish Release
     needs: [validate, build-assets]
@@ -99,7 +122,7 @@ jobs:
       contents: write
 
     steps:
-      - name: Download all tarballs
+      - name: Download all artifacts
         uses: actions/download-artifact@v7
         with:
           path: dist
@@ -109,12 +132,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          echo "Release assets:" 
-          (cd dist && find . -maxdepth 3 -type f -name '*.tar.gz' -print | sed 's|^\./||' | sort)
+          echo "Release assets:"
+          (cd dist && find . -maxdepth 3 -type f \( -name '*.tar.gz' -o -name '*.deb' \) -print | sed 's|^\./||' | sort)
 
-          files=$(cd dist && find . -maxdepth 3 -type f -name '*.tar.gz' -print | sed 's|^\./||')
+          files=$(cd dist && find . -maxdepth 3 -type f \( -name '*.tar.gz' -o -name '*.deb' \) -print | sed 's|^\./||')
           if [[ -z "$files" ]]; then
-            echo "ERROR: No .tar.gz files found under dist/" >&2
+            echo "ERROR: No release files found under dist/" >&2
             exit 1
           fi
 
@@ -154,4 +177,5 @@ jobs:
           body_path: release-body.md
           files: |
             dist/**/keystone-cli_${{ needs.validate.outputs.version }}_*.tar.gz
+            dist/**/keystone-cli_${{ needs.validate.outputs.version }}_*.deb
             checksums.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,9 @@ keystone-cli/
 │   └── release.yml                 # Release notes configuration
 ├── CONTRIBUTING.md                 # Contribution guidelines
 ├── scripts/                        # Build and utility scripts
-│   └── package-release.sh          # Tarball packaging script
+│   ├── package-release.sh          # Tarball packaging script
+│   └── package-deb.sh              # Debian package script (requires nfpm)
+├── nfpm.yaml                       # nfpm configuration for .deb packaging
 ├── artifacts/                      # Build outputs
 ├── Directory.Build.props           # MSBuild configuration
 └── keystone-cli.sln                # Visual Studio solution
@@ -229,7 +231,7 @@ Template repository URLs are configurable via settings.
 - **ci.yml**: Runs unit tests on PRs and pushes to main
 - **tag-release.yml**: Manual workflow to create a version tag from csproj version
 - **release.yml**: Triggered by `v*.*.*` tags; validates version, builds multi-platform
-  binaries, generates checksums, and publishes GitHub Release
+  binaries, packages tarballs and .deb files, generates checksums, and publishes GitHub Release
 
 ### Release Flow
 
@@ -252,3 +254,6 @@ Template repository URLs are configurable via settings.
 
 - **package-release.sh**: Creates release tarballs with binary, config, and man page;
   generates SHA256 checksums. Usage: `./scripts/package-release.sh [version] [rid]`
+- **package-deb.sh**: Creates `.deb` packages for Linux (amd64, arm64) using nfpm;
+  requires `nfpm` (`brew install nfpm` or `go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest`).
+  Usage: `./scripts/package-deb.sh [version] [rid]`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ publishing books and documents. It is part of the broader Keystone ecosystem, wh
 
 ## Installation
 
-Keystone CLI is distributed via Homebrew.
+### Homebrew (macOS/Linux)
 
 First, add the Knight Owl Homebrew tap:
 
@@ -39,6 +39,12 @@ After installation, verify that everything is working:
 keystone-cli info
 man keystone-cli
 ```
+
+### Apt (Debian/Ubuntu) — Coming Soon
+
+See [issue #49](https://github.com/knight-owl-dev/keystone-cli/issues/49) for progress on apt
+repository support. In the meantime, `.deb` packages are available in
+[GitHub Releases](https://github.com/Knight-Owl-Dev/keystone-cli/releases).
 
 ## Project Structure
 

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,24 @@
+name: keystone-cli
+arch: "${ARCH}"
+version: "${VERSION}"
+maintainer: "Knight Owl Dev"
+description: "A command-line interface for Keystone"
+homepage: "https://github.com/knight-owl-dev/keystone-cli"
+license: "MIT"
+
+contents:
+  - src: artifacts/bin/Keystone.Cli/Release/net10.0/${RID}/publish/keystone-cli
+    dst: /opt/keystone-cli/keystone-cli
+    expand: true
+    file_info:
+      mode: 0755
+  - src: artifacts/bin/Keystone.Cli/Release/net10.0/${RID}/publish/appsettings.json
+    dst: /opt/keystone-cli/appsettings.json
+    expand: true
+  - src: docs/man/man1/keystone-cli.1
+    dst: /usr/local/share/man/man1/keystone-cli.1
+  - src: LICENSE
+    dst: /usr/share/doc/keystone-cli/copyright
+  - dst: /usr/local/bin/keystone-cli
+    type: symlink
+    src: /opt/keystone-cli/keystone-cli

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Always run relative to the repo root.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+VERSION=""
+RID=""
+
+usage() {
+  echo "Usage: $(basename "$0") [version] [rid]" >&2
+  echo "  version: Optional release version (e.g., 0.1.0)." >&2
+  echo "           Defaults to the current <Version> value in Keystone.Cli.csproj if omitted." >&2
+  echo "  rid:     Optional runtime identifier (linux-x64 or linux-arm64)." >&2
+  echo "           If provided, only that RID package will be produced." >&2
+  echo "" >&2
+  echo "Examples:" >&2
+  echo "  $(basename "$0")" >&2
+  echo "  $(basename "$0") 0.1.0" >&2
+  echo "  $(basename "$0") 0.1.0 linux-x64" >&2
+  echo "  $(basename "$0") linux-arm64" >&2
+}
+
+if [[ $# -gt 2 ]]; then
+  usage
+  exit 2
+fi
+
+if [[ $# -eq 1 ]]; then
+  # Support either "version" OR "rid" as the sole argument.
+  if [[ "$1" =~ ^linux- ]]; then
+    RID="$1"
+  else
+    VERSION="$1"
+  fi
+fi
+
+if [[ $# -eq 2 ]]; then
+  VERSION="$1"
+  RID="$2"
+fi
+
+TFM="net10.0"
+
+if [[ -z "$VERSION" ]]; then
+  # Best-effort: extract <Version>...</Version> from the CLI project file.
+  if [[ -f "./src/Keystone.Cli/Keystone.Cli.csproj" ]]; then
+    VERSION="$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' ./src/Keystone.Cli/Keystone.Cli.csproj | head -n 1)"
+  fi
+
+  if [[ -z "$VERSION" ]]; then
+    VERSION="0.1.0"
+  fi
+fi
+
+OUT_DIR="artifacts/release"
+
+mkdir -p "$OUT_DIR"
+
+# Check for nfpm
+if ! command -v nfpm >/dev/null 2>&1; then
+  echo "ERROR: nfpm is not installed." >&2
+  echo "Install with: brew install nfpm" >&2
+  echo "         or: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest" >&2
+  exit 1
+fi
+
+package() {
+  local RID="$1"
+  local ARCH
+
+  case "$RID" in
+    linux-x64)  ARCH="amd64" ;;
+    linux-arm64) ARCH="arm64" ;;
+    *)
+      echo "ERROR: Unsupported RID for .deb packaging: $RID" >&2
+      echo "Supported RIDs: linux-x64, linux-arm64" >&2
+      exit 1
+      ;;
+  esac
+
+  local PUBLISH_DIR="artifacts/bin/Keystone.Cli/Release/${TFM}/${RID}/publish"
+
+  if [[ ! -d "$PUBLISH_DIR" ]]; then
+    echo "ERROR: Publish directory not found: $PUBLISH_DIR" >&2
+    echo "Run: dotnet publish ./src/Keystone.Cli/Keystone.Cli.csproj -c Release -r $RID" >&2
+    exit 1
+  fi
+
+  if [[ ! -f "$PUBLISH_DIR/keystone-cli" ]]; then
+    echo "ERROR: Expected binary not found: $PUBLISH_DIR/keystone-cli" >&2
+    exit 1
+  fi
+
+  if [[ ! -f "$PUBLISH_DIR/appsettings.json" ]]; then
+    echo "ERROR: Expected config not found: $PUBLISH_DIR/appsettings.json" >&2
+    exit 1
+  fi
+
+  if [[ ! -f "docs/man/man1/keystone-cli.1" ]]; then
+    echo "ERROR: Man page not found: docs/man/man1/keystone-cli.1" >&2
+    exit 1
+  fi
+
+  if [[ ! -f "LICENSE" ]]; then
+    echo "ERROR: LICENSE file not found" >&2
+    exit 1
+  fi
+
+  local PACKAGE="${OUT_DIR}/keystone-cli_${VERSION}_${ARCH}.deb"
+
+  echo "Building ${PACKAGE} (RID: ${RID}, ARCH: ${ARCH})"
+
+  ARCH="$ARCH" VERSION="$VERSION" RID="$RID" \
+    nfpm package --packager deb --target "$PACKAGE"
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$PACKAGE"
+  else
+    sha256sum "$PACKAGE"
+  fi
+}
+
+if [[ -n "$RID" ]]; then
+  package "$RID"
+else
+  package linux-x64
+  package linux-arm64
+fi
+
+echo "Done."


### PR DESCRIPTION
## Summary

Enable `.deb` package generation as part of the release workflow, laying the groundwork for future apt repository distribution. This delivers the package generation portion of #49 while deferring GPG signing and apt repository hosting to follow-up work.

## Related Issues

Refs #49

## Changes

- Add `nfpm.yaml` configuration for Debian package generation with correct file mappings
- Add `scripts/package-deb.sh` for building `.deb` packages locally and in CI
- Update `release.yml` to build and upload `.deb` packages for `linux-x64` and `linux-arm64`
- Include `.deb` files in `checksums.txt` alongside tarballs
- Update documentation (README, how-to-release, CLAUDE.md)

## Further Comments

The `.deb` packages are now published to GitHub Releases alongside tarballs. Package contents:

- `/opt/keystone-cli/keystone-cli` — binary
- `/opt/keystone-cli/appsettings.json` — config
- `/usr/local/share/man/man1/keystone-cli.1` — man page
- `/usr/share/doc/keystone-cli/copyright` — license
- `/usr/local/bin/keystone-cli` — symlink

Remaining work for #49: GPG signing and apt repository hosting.