### PR TITLE
Add LICENSE file validation to package-release.sh

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -87,6 +87,11 @@ package() {
     exit 1
   fi
 
+  if [[ ! -f "LICENSE" ]]; then
+    echo "ERROR: LICENSE file not found: LICENSE" >&2
+    exit 1
+  fi
+
   local ARCHIVE="${OUT_DIR}/keystone-cli_${VERSION}_${RID}.tar.gz"
 
   echo "Packaging ${ARCHIVE} (RID: ${RID})"


### PR DESCRIPTION
## Summary

Ensures the packaging script fails fast with a clear error message if the LICENSE file is missing, rather than failing during the tar command or producing an incomplete archive.

## Related Issues

Fixes #59

## Changes

- Add LICENSE file existence check in the `package()` function, following the existing validation pattern