### PR TITLE
Bump version to `0.1.8` in project files and documentation

### DIFF
--- a/docs/man/man1/keystone-cli.1
+++ b/docs/man/man1/keystone-cli.1
@@ -213,7 +213,7 @@ executable.
 .El
 
 .Sh VERSION
-keystone-cli 0.1.7
+keystone-cli 0.1.8
 
 .Sh AUTHOR
 Knight Owl LLC

--- a/src/Keystone.Cli/Keystone.Cli.csproj
+++ b/src/Keystone.Cli/Keystone.Cli.csproj
@@ -12,11 +12,11 @@
         <Copyright>© 2025 Knight Owl LLC. All rights reserved.</Copyright>
         <Description>A command-line interface for Keystone.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>0.1.7</Version>
-        <ApplicationVersion>0.1.7</ApplicationVersion>
-        <AssemblyVersion>0.1.7</AssemblyVersion>
-        <FileVersion>0.1.7</FileVersion>
-        <InformationalVersion>0.1.7</InformationalVersion>
+        <Version>0.1.8</Version>
+        <ApplicationVersion>0.1.8</ApplicationVersion>
+        <AssemblyVersion>0.1.8</AssemblyVersion>
+        <FileVersion>0.1.8</FileVersion>
+        <InformationalVersion>0.1.8</InformationalVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/tests/Keystone.Cli.UnitTests/Application/Commands/Info/InfoCommandTests.cs
+++ b/tests/Keystone.Cli.UnitTests/Application/Commands/Info/InfoCommandTests.cs
@@ -33,7 +33,7 @@ public class InfoCommandTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(actual.Version, Does.StartWith("0.1.7"));
+            Assert.That(actual.Version, Does.StartWith("0.1.8"));
             Assert.That(actual.Description, Is.EqualTo("A command-line interface for Keystone."));
             Assert.That(actual.Copyright, Is.EqualTo("© 2025 Knight Owl LLC. All rights reserved."));
             Assert.That(actual.DefaultTemplateTarget, Is.EqualTo(defaultTemplateTarget));


### PR DESCRIPTION
## Summary

- Bump version from 0.1.7 to 0.1.8 in csproj (all 5 version properties)
- Update VERSION section in man page
- Update version assertion in unit tests