### PR TITLE
Disable Go cache in release workflow (#62)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: stable
+          cache: false
 
       - name: Install nfpm
         if: startsWith(matrix.rid, 'linux-')


### PR DESCRIPTION
## Summary

Eliminate the "Restore cache failed" warning in the release workflow. Go is only used as a tool to install `nfpm` for building `.deb` packages—this is not a Go project, so there is no `go.sum` file for caching.

## Related Issues

Fixes #62

## Changes

- Add `cache: false` to the `actions/setup-go@v6` step in `.github/workflows/release.yml`