### PR TITLE
Extract target framework into a reusable script (#69)

### DIFF
--- a/scripts/get-tfm.sh
+++ b/scripts/get-tfm.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PROPS_PATH="$REPO_ROOT/Directory.Build.props"
+
+TFM="$(sed -n 's:.*<TargetFramework>\(.*\)</TargetFramework>.*:\1:p' "$PROPS_PATH" | head -n 1)"
+
+if [[ -z "$TFM" ]]; then
+  echo "ERROR: Could not read <TargetFramework> from $PROPS_PATH" >&2
+  exit 1
+fi
+
+echo "$TFM"

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -42,7 +42,7 @@ if [[ $# -eq 2 ]]; then
   RID="$2"
 fi
 
-TFM="net10.0"
+TFM="$("${SCRIPT_DIR}/get-tfm.sh")"
 
 if [[ -z "$VERSION" ]]; then
   # Best-effort: extract <Version>...</Version> from the CLI project file.

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -43,7 +43,7 @@ if [[ $# -eq 2 ]]; then
   RID="$2"
 fi
 
-TFM="net10.0"
+TFM="$("${SCRIPT_DIR}/get-tfm.sh")"
 
 if [[ -z "$VERSION" ]]; then
   # Best-effort: extract <Version>...</Version> from the CLI project file.


### PR DESCRIPTION
## Summary

Eliminates hardcoded target framework (`net10.0`) in packaging scripts by extracting it from `Directory.Build.props`. This establishes a single source of truth for TFM, reducing the risk of scripts falling out of sync when upgrading .NET versions.

## Related Issues

Fixes #69

## Changes

- Add `scripts/get-tfm.sh` that extracts `<TargetFramework>` from `Directory.Build.props`
- Update `scripts/package-release.sh` to use the new script instead of hardcoded TFM
- Update `scripts/package-deb.sh` to use the new script instead of hardcoded TFM