### PR TITLE
Use `get-version.sh` in package scripts and remove fallback version logic

### DIFF
--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -12,7 +12,7 @@ RID=""
 usage() {
   echo "Usage: $(basename "$0") [version] [rid]" >&2
   echo "  version: Optional release version (e.g., 0.1.0)." >&2
-  echo "           Defaults to the current <Version> value in Keystone.Cli.csproj if omitted." >&2
+  echo "           Extracted from Keystone.Cli.csproj if omitted; fails if not found." >&2
   echo "  rid:     Optional runtime identifier (linux-x64 or linux-arm64)." >&2
   echo "           If provided, only that RID package will be produced." >&2
   echo "" >&2
@@ -45,14 +45,7 @@ fi
 TFM="$("${SCRIPT_DIR}/get-tfm.sh")"
 
 if [[ -z "$VERSION" ]]; then
-  # Best-effort: extract <Version>...</Version> from the CLI project file.
-  if [[ -f "./src/Keystone.Cli/Keystone.Cli.csproj" ]]; then
-    VERSION="$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' ./src/Keystone.Cli/Keystone.Cli.csproj | head -n 1)"
-  fi
-
-  if [[ -z "$VERSION" ]]; then
-    VERSION="0.1.0"
-  fi
+  VERSION="$("${SCRIPT_DIR}/get-version.sh")"
 fi
 
 OUT_DIR="artifacts/release"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -13,7 +13,7 @@ RID=""
 usage() {
   echo "Usage: $(basename "$0") [version] [rid]" >&2
   echo "  version: Optional release version (e.g., 0.1.0)." >&2
-  echo "           Defaults to the current <Version> value in Keystone.Cli.csproj if omitted." >&2
+  echo "           Extracted from Keystone.Cli.csproj if omitted; fails if not found." >&2
   echo "  rid:     Optional runtime identifier (e.g., osx-arm64, osx-x64, linux-x64)." >&2
   echo "           If provided, only that RID archive will be produced." >&2
   echo "" >&2
@@ -46,15 +46,7 @@ fi
 TFM="$("${SCRIPT_DIR}/get-tfm.sh")"
 
 if [[ -z "$VERSION" ]]; then
-  # Best-effort: extract <Version>...</Version> from the CLI project file.
-  # (Keeps this script dependency-free; falls back to 0.1.0 if not found.)
-  if [[ -f "./src/Keystone.Cli/Keystone.Cli.csproj" ]]; then
-    VERSION="$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' ./src/Keystone.Cli/Keystone.Cli.csproj | head -n 1)"
-  fi
-
-  if [[ -z "$VERSION" ]]; then
-    VERSION="0.1.0"
-  fi
+  VERSION="$("${SCRIPT_DIR}/get-version.sh")"
 fi
 
 OUT_DIR="artifacts/release"


### PR DESCRIPTION
## Summary

Consolidates version extraction in the packaging scripts by using the shared `get-version.sh` script introduced in #68. This eliminates code duplication and ensures packaging fails fast with a clear error instead of silently defaulting to `0.1.0` when the version cannot be determined.

## Related Issues

Fixes #70

## Changes

- Replace inline `sed` version extraction in `package-deb.sh` and `package-release.sh` with calls to `get-version.sh`
- Remove fallback logic that defaulted to `0.1.0` when version was not found
- Update usage text in both scripts to reflect the new fail-fast behavior