### PR TITLE
Use TFM environment variable in nfpm configuration

### DIFF
--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -7,12 +7,12 @@ homepage: "https://github.com/knight-owl-dev/keystone-cli"
 license: "MIT"
 
 contents:
-  - src: artifacts/bin/Keystone.Cli/Release/net10.0/${RID}/publish/keystone-cli
+  - src: artifacts/bin/Keystone.Cli/Release/${TFM}/${RID}/publish/keystone-cli
     dst: /opt/keystone-cli/keystone-cli
     expand: true
     file_info:
       mode: 0755
-  - src: artifacts/bin/Keystone.Cli/Release/net10.0/${RID}/publish/appsettings.json
+  - src: artifacts/bin/Keystone.Cli/Release/${TFM}/${RID}/publish/appsettings.json
     dst: /opt/keystone-cli/appsettings.json
     expand: true
   - src: docs/man/man1/keystone-cli.1

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -106,7 +106,7 @@ package() {
 
   echo "Building ${PACKAGE} (RID: ${RID}, ARCH: ${ARCH})"
 
-  ARCH="$ARCH" VERSION="$VERSION" RID="$RID" \
+  ARCH="$ARCH" VERSION="$VERSION" RID="$RID" TFM="$TFM" \
     nfpm package --packager deb --target "$PACKAGE"
 
   if command -v shasum >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Replace hardcoded target framework in nfpm packaging configuration with a parameterized environment variable. This ensures all path components that may change between releases (VERSION, RID, TFM) are consistently passed as environment variables rather than hardcoded values.

## Related Issues

Fixes #71

## Changes

- Update `nfpm.yaml` to use `${TFM}` instead of hardcoded `net10.0` in content paths
- Update `package-deb.sh` to pass `TFM` as an environment variable to nfpm