### PR TITLE
Add how-to guide for upgrading .NET versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ keystone-cli/
 │   ├── how-to/                     # Procedural guides
 │   │   ├── how-to-release.md       # Release process documentation
 │   │   ├── how-to-test-man-page.md # Man page testing guide
+│   │   ├── how-to-upgrade-dotnet.md # .NET version upgrade guide
 │   │   └── how-to-workflow.md      # Development workflow guide
 │   └── man/                        # Manual pages in mdoc format
 ├── .github/
@@ -45,6 +46,7 @@ keystone-cli/
 ├── scripts/                        # Build and utility scripts
 │   ├── generate-checksums.sh       # SHA256 checksum generation for releases
 │   ├── get-english-month-year.sh   # Locale-safe date for man page updates
+│   ├── get-tfm.sh                  # Extract target framework from Directory.Build.props
 │   ├── get-version.sh              # Extract version from csproj
 │   ├── package-deb.sh              # Debian package script (requires nfpm)
 │   └── package-release.sh          # Tarball packaging script
@@ -226,6 +228,8 @@ Template repository URLs are configurable via settings.
 - Self-contained single-file publishing enabled
 - Deterministic builds for CI/CD
 - Centralized build outputs in `artifacts/` directory
+- Target framework defined centrally in `Directory.Build.props`; see
+  `docs/how-to/how-to-upgrade-dotnet.md` for upgrade instructions
 
 ## CI/CD and Release Process
 
@@ -259,6 +263,8 @@ Template repository URLs are configurable via settings.
   Usage: `./scripts/generate-checksums.sh [dist-dir]`
 - **get-english-month-year.sh**: Returns locale-safe English month and year for man page updates.
   Usage: `./scripts/get-english-month-year.sh`
+- **get-tfm.sh**: Extracts the target framework moniker from `Directory.Build.props`.
+  Usage: `./scripts/get-tfm.sh`
 - **get-version.sh**: Extracts the project version from `Keystone.Cli.csproj`.
   Usage: `./scripts/get-version.sh`
 - **package-deb.sh**: Creates `.deb` packages for Linux (amd64, arm64) using nfpm;

--- a/docs/how-to/how-to-upgrade-dotnet.md
+++ b/docs/how-to/how-to-upgrade-dotnet.md
@@ -1,0 +1,87 @@
+# How to Upgrade .NET Versions
+
+This guide explains how to upgrade the project to a new .NET version (e.g., from .NET 10 to .NET 11).
+
+## Overview
+
+The project is designed to minimize hardcoded .NET version references. The target framework is
+defined in a single location, and packaging scripts dynamically extract this value at runtime.
+This architecture means most files automatically adapt when you update the central configuration.
+
+## Architecture
+
+### Single Source of Truth
+
+The target framework is defined once in [`Directory.Build.props`](../../Directory.Build.props).
+All `.csproj` files inherit this value, so there's no need to update individual project files.
+
+### Dynamic Path Resolution
+
+Packaging scripts use [`scripts/get-tfm.sh`](../../scripts/get-tfm.sh) to extract the target
+framework at runtime. This value constructs artifact paths like
+`artifacts/bin/Keystone.Cli/Release/${TFM}/${RID}/publish`.
+
+The following files use dynamic resolution and **do not need manual updates**:
+
+- [`scripts/get-tfm.sh`](../../scripts/get-tfm.sh)
+- [`scripts/package-release.sh`](../../scripts/package-release.sh)
+- [`scripts/package-deb.sh`](../../scripts/package-deb.sh)
+- [`nfpm.yaml`](../../nfpm.yaml)
+
+## Upgrade Checklist
+
+When upgrading to a new .NET version, update these files:
+
+### 1. Directory.Build.props
+
+Update the `<TargetFramework>` element in
+[`Directory.Build.props`](../../Directory.Build.props).
+
+### 2. GitHub Workflows
+
+Update the `dotnet-version` in the `setup-dotnet` action across three workflow files:
+
+- [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) — Setup .NET step
+- [`.github/workflows/release.yml`](../../.github/workflows/release.yml) — Setup .NET steps
+  in both `validate` and `build-assets` jobs
+- [`.github/workflows/tag-release.yml`](../../.github/workflows/tag-release.yml) — Setup .NET step
+
+### 3. CLAUDE.md (Optional)
+
+If the Framework and Dependencies section in [`CLAUDE.md`](../../CLAUDE.md) mentions a specific
+.NET version, update it to match.
+
+## Verification
+
+After making the changes, verify the upgrade:
+
+```bash
+# Clean previous build artifacts
+rm -rf artifacts
+
+# Restore and build
+dotnet restore
+dotnet build
+
+# Run tests
+dotnet test
+
+# Verify the target framework is detected correctly
+./scripts/get-tfm.sh
+
+# Test publishing (optional)
+dotnet publish src/Keystone.Cli -c Release -r osx-arm64
+```
+
+## Summary
+
+| File                                | Update Required | Notes                                 |
+|-------------------------------------|-----------------|---------------------------------------|
+| `Directory.Build.props`             | Yes             | Single source of truth for TFM        |
+| `.github/workflows/ci.yml`          | Yes             | SDK version for CI                    |
+| `.github/workflows/release.yml`     | Yes             | SDK version (2 locations)             |
+| `.github/workflows/tag-release.yml` | Yes             | SDK version for tagging               |
+| `CLAUDE.md`                         | Optional        | Documentation reference               |
+| `scripts/*.sh`                      | No              | Uses dynamic `${TFM}`                 |
+| `nfpm.yaml`                         | No              | Uses dynamic `${TFM}`                 |
+| `*.csproj`                          | No              | Inherits from `Directory.Build.props` |


### PR DESCRIPTION
## Summary

Provides documentation for upgrading the project to future .NET releases, explaining the architecture that minimizes hardcoded version references and listing the specific files that need updates.

## Related Issues

Fixes #75

## Changes

- Add `docs/how-to/how-to-upgrade-dotnet.md` with upgrade checklist and verification steps
- Update `CLAUDE.md` to include `get-tfm.sh` in project structure and scripts sections
- Add reference to the upgrade guide in Build Configuration section