### PR TITLE
Validate man page date month is not in the future for current year

### DIFF
--- a/src/Keystone.Cli/Domain/CliInfo.cs
+++ b/src/Keystone.Cli/Domain/CliInfo.cs
@@ -16,11 +16,18 @@ public static class CliInfo
     public const int InceptionYear = 2025;
 
     /// <summary>
-    /// The current year in local time.
+    /// Returns the current local date.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Uses local time to match the date script (<c>scripts/get-english-month-year.sh</c>),
-    /// which uses <c>date '+%Y'</c> (local time, not UTC).
+    /// which uses <c>date</c> without UTC flags.
+    /// </para>
+    /// <para>
+    /// Returning a single <see cref="DateOnly"/> ensures atomic access to year and month,
+    /// avoiding race conditions at year/month boundaries.
+    /// </para>
     /// </remarks>
-    public static int CurrentYear => DateTime.Now.Year;
+    public static DateOnly GetLocalDate()
+        => DateOnly.FromDateTime(DateTime.Now);
 }


### PR DESCRIPTION
## Summary

Ensure the man page date validation test catches future months when the year is the current year, preventing accidental commits of dates that haven't occurred yet (e.g., setting "March 2026" when it's currently January 2026). The validation is locale-independent, using a hardcoded lookup against the existing `ValidEnglishMonths` array.

## Related Issues

Fixes #77

## Changes

- Replace `CliInfo.CurrentYear` property with `GetLocalDate()` method returning `DateOnly` to ensure atomic access to year and month, avoiding race conditions at year/month boundaries
- Update `ManPageDateTagTests` to validate that when the man page year equals the current year, the month must not be in the future