### PR TITLE
Add explicit `IsTestProject` property to test project

### DIFF
--- a/tests/Keystone.Cli.UnitTests/Keystone.Cli.UnitTests.csproj
+++ b/tests/Keystone.Cli.UnitTests/Keystone.Cli.UnitTests.csproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

Make the test project configuration explicit rather than relying on SDK auto-detection. This improves clarity and ensures consistent behavior across different SDK versions and tooling.

## Related Issues

Fixes #78

## Changes

- Add `<IsTestProject>true</IsTestProject>` to the unit test project's `PropertyGroup`