### PR TITLE
Fix template comparison in SwitchTemplateAsync to use repository names

### DIFF
--- a/src/Keystone.Cli/Application/Project/ProjectService.cs
+++ b/src/Keystone.Cli/Application/Project/ProjectService.cs
@@ -76,7 +76,7 @@ public partial class ProjectService(
 
         var originalProjectModel = await projectModelRepository.LoadAsync(fullPathToProject, cancellationToken);
 
-        if (originalProjectModel.KeystoneSync?.TemplateRepositoryName == templateTarget.Name)
+        if (originalProjectModel.KeystoneSync?.TemplateRepositoryName == templateTarget.RepositoryName)
         {
             LogProjectAlreadyUsesRepository(logger, originalProjectModel.ProjectName!, templateTarget.RepositoryUrl);
 

--- a/src/Keystone.Cli/Domain/TemplateTargetModel.cs
+++ b/src/Keystone.Cli/Domain/TemplateTargetModel.cs
@@ -6,4 +6,10 @@ namespace Keystone.Cli.Domain;
 /// <param name="Name">The name associated with the template target.</param>
 /// <param name="RepositoryUrl">The repository URL.</param>
 /// <param name="BranchName">The target branch name.</param>
-public record TemplateTargetModel(string Name, Uri RepositoryUrl, string BranchName = "main");
+public record TemplateTargetModel(string Name, Uri RepositoryUrl, string BranchName = "main")
+{
+    /// <summary>
+    /// Gets the repository name extracted from the <see cref="RepositoryUrl"/>.
+    /// </summary>
+    public string RepositoryName => this.RepositoryUrl.Segments[^1].TrimEnd('/');
+}

--- a/tests/Keystone.Cli.UnitTests/Application/Project/ProjectServiceTests.cs
+++ b/tests/Keystone.Cli.UnitTests/Application/Project/ProjectServiceTests.cs
@@ -218,6 +218,7 @@ public class ProjectServiceTests
         const string projectName = "existing-project";
         const string fullPath = "/path/to/project";
         const string templateName = "core";
+        const string repositoryName = "template-core";
         const string repositoryUrl = "https://github.com/knight-owl-dev/template-core";
 
         var templateTarget = new TemplateTargetModel(
@@ -231,7 +232,7 @@ public class ProjectServiceTests
         var existingProject = new ProjectModel(fullPath)
         {
             ProjectName = projectName,
-            KeystoneSync = new KeystoneSyncModel(templateName),
+            KeystoneSync = new KeystoneSyncModel(repositoryName),
         };
 
         var projectModelRepository = Substitute.For<IProjectModelRepository>();
@@ -260,6 +261,7 @@ public class ProjectServiceTests
         const string projectName = "existing-project";
         const string fullPath = "/path/to/project";
         const string newTemplateName = "core-slim";
+        const string newRepositoryName = "template-core-slim";
         const string repositoryUrl = "https://github.com/knight-owl-dev/template-core-slim";
 
         var templateTarget = new TemplateTargetModel(
@@ -280,7 +282,7 @@ public class ProjectServiceTests
         var refreshedProject = new ProjectModel(fullPath)
         {
             ProjectName = "template-default-name",
-            KeystoneSync = new KeystoneSyncModel(newTemplateName),
+            KeystoneSync = new KeystoneSyncModel(newRepositoryName),
         };
 
         var gitHubService = Substitute.For<IGitHubService>();
@@ -319,8 +321,9 @@ public class ProjectServiceTests
     {
         const string projectName = "existing-project";
         const string fullPath = "/path/to/project";
-        const string oldTemplateName = "core";
         const string newTemplateName = "core-slim";
+        const string oldRepositoryName = "template-core";
+        const string newRepositoryName = "template-core-slim";
         const string repositoryUrl = "https://github.com/knight-owl-dev/template-core-slim";
 
         var templateTarget = new TemplateTargetModel(
@@ -335,13 +338,13 @@ public class ProjectServiceTests
         var originalProject = new ProjectModel(fullPath)
         {
             ProjectName = projectName,
-            KeystoneSync = new KeystoneSyncModel(oldTemplateName),
+            KeystoneSync = new KeystoneSyncModel(oldRepositoryName),
         };
 
         var refreshedProject = new ProjectModel(fullPath)
         {
             ProjectName = "template-default-name",
-            KeystoneSync = new KeystoneSyncModel(newTemplateName),
+            KeystoneSync = new KeystoneSyncModel(newRepositoryName),
         };
 
         var gitHubService = Substitute.For<IGitHubService>();

--- a/tests/Keystone.Cli.UnitTests/Domain/TemplateTargetModelTests.cs
+++ b/tests/Keystone.Cli.UnitTests/Domain/TemplateTargetModelTests.cs
@@ -1,0 +1,30 @@
+using Keystone.Cli.Domain;
+
+
+namespace Keystone.Cli.UnitTests.Domain;
+
+[TestFixture, Parallelizable(ParallelScope.All)]
+public class TemplateTargetModelTests
+{
+    [Test]
+    public void RepositoryName_ExtractsLastSegmentFromUrl()
+    {
+        var sut = new TemplateTargetModel(
+            Name: "core",
+            RepositoryUrl: new Uri("https://github.com/knight-owl-dev/template-core")
+        );
+
+        Assert.That(sut.RepositoryName, Is.EqualTo("template-core"));
+    }
+
+    [Test]
+    public void RepositoryName_WhenUrlHasTrailingSlash_TrimsSlash()
+    {
+        var sut = new TemplateTargetModel(
+            Name: "core",
+            RepositoryUrl: new Uri("https://github.com/knight-owl-dev/template-core/")
+        );
+
+        Assert.That(sut.RepositoryName, Is.EqualTo("template-core"));
+    }
+}


### PR DESCRIPTION
## Summary

The `SwitchTemplateAsync` method was comparing `KeystoneSyncModel.TemplateRepositoryName` (e.g., `keystone-template-core-slim`) with `TemplateTargetModel.Name` (e.g., `core-slim`), which never matched. This caused the switch command to re-copy template files even when the project already used the target template.

This PR fixes the comparison by adding a `RepositoryName` computed property to `TemplateTargetModel` that extracts the repository name from the URL, enabling a correct comparison.

## Related Issues

Fixes #83

## Changes

- Add `RepositoryName` property to `TemplateTargetModel` that extracts the last URL segment
- Update `SwitchTemplateAsync` to compare repository names correctly
- Update tests to use realistic repository names in `KeystoneSyncModel`
- Add unit tests for the new `RepositoryName` property