### PR TITLE
Add launch configurations for template switching scenarios (#89)

### DIFF
--- a/src/Keystone.Cli/Properties/launchSettings.json
+++ b/src/Keystone.Cli/Properties/launchSettings.json
@@ -22,6 +22,20 @@
       },
       "commandLineArgs": "new hello-world"
     },
+    "project-switch-template-core": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      },
+      "commandLineArgs": "project switch-template --project-path hello-world core"
+    },
+    "project-switch-template-core-slim": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      },
+      "commandLineArgs": "project switch-template --project-path hello-world core-slim"
+    },
     "help": {
       "commandName": "Project",
       "environmentVariables": {


### PR DESCRIPTION
## Summary

Enable local testing of template switching workflows between `core` and `core-slim` templates. This allows developers to quickly validate the `project switch-template` command without manual CLI invocation.

## Related Issues

Fixes #89

## Changes

- Add `project-switch-template-core` launch configuration to switch projects to the `core` template
- Add `project-switch-template-core-slim` launch configuration to switch projects to the `core-slim` template
- Both configurations target the `hello-world` project created by the existing `new` launch profile