### PR TITLE
Add issue-comment command for posting comments to GitHub issues

### DIFF
--- a/.claude/commands/issue-comment.md
+++ b/.claude/commands/issue-comment.md
@@ -139,7 +139,7 @@ If the user chose "Save thoughts":
 
    ```markdown
    <details>
-   <summary>📝 Dev Notes — <current date></summary>
+   <summary>📝 Dev Notes — <current date in YYYY-MM-DD format></summary>
 
    <user's thoughts>
 
@@ -196,5 +196,5 @@ After successful posting:
 - **Issue not found**: Inform user the issue doesn't exist
 - **No network/auth**: Remind user to check `gh auth status`
 - **Empty comment**: Do not allow posting empty comments
-- **Not on issue branch**: If progress update is selected but not on an issue branch, fall back to simple comment with a
-  note
+- **Not on issue branch**: If a progress update is selected but the current branch does not match an issue pattern, fall
+  back to a simple comment and inform the user: "Note: No issue branch detected; git context will not be included."


### PR DESCRIPTION
## Summary

Enable developers to post comments to GitHub issues directly from the CLI. This command supports simple text comments, structured progress updates with commit and file context, and collapsible dev notes for saving thoughts. Combined with the existing `issue-checkout` command, developers can now manage their complete issue workflow without leaving the terminal.

## Related Issues

Fixes #93

## Changes

- Add `/issue-comment` skill command with three comment types: simple, progress update, and save thoughts
- Auto-detect issue number from current branch name (e.g., `93-add-issue-comment-command`)
- Include git context (commits, changed files) in progress updates
- Format dev notes as collapsible sections with timestamp and branch info