### PR TITLE
Update apt repository dispatch payload for multi-package support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,4 +184,4 @@ jobs:
           token: ${{ secrets.APT_REPO_TOKEN }}
           repository: knight-owl-dev/apt
           event-type: release-published
-          client-payload: '{"version": "${{ needs.validate.outputs.version }}"}'
+          client-payload: '{"versions": "keystone-cli:${{ needs.validate.outputs.version }}"}'


### PR DESCRIPTION
## Summary

Update the release workflow's repository dispatch payload to match the apt repository's new multi-package architecture. This enables the apt repo to support multiple packages with package-specific versioning.

## Related Issues

Fixes #105

## Changes

- Change payload key from `version` to `versions`
- Change value format from `"0.1.9"` to `"keystone-cli:0.1.9"`

🤖 Generated with [Claude Code](https://claude.ai/code)