### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/docs/man/man1/keystone-cli.1
+++ b/docs/man/man1/keystone-cli.1
@@ -213,7 +213,7 @@ executable.
 .El
 
 .Sh VERSION
-keystone-cli 0.1.9
+keystone-cli 0.2.0
 
 .Sh AUTHOR
 Knight Owl LLC

--- a/src/Keystone.Cli/Keystone.Cli.csproj
+++ b/src/Keystone.Cli/Keystone.Cli.csproj
@@ -12,11 +12,11 @@
         <Copyright>© 2025 Knight Owl LLC. All rights reserved.</Copyright>
         <Description>A command-line interface for Keystone.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>0.1.9</Version>
-        <ApplicationVersion>0.1.9</ApplicationVersion>
-        <AssemblyVersion>0.1.9</AssemblyVersion>
-        <FileVersion>0.1.9</FileVersion>
-        <InformationalVersion>0.1.9</InformationalVersion>
+        <Version>0.2.0</Version>
+        <ApplicationVersion>0.2.0</ApplicationVersion>
+        <AssemblyVersion>0.2.0</AssemblyVersion>
+        <FileVersion>0.2.0</FileVersion>
+        <InformationalVersion>0.2.0</InformationalVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/tests/Keystone.Cli.UnitTests/Application/Commands/Info/InfoCommandTests.cs
+++ b/tests/Keystone.Cli.UnitTests/Application/Commands/Info/InfoCommandTests.cs
@@ -33,7 +33,7 @@ public class InfoCommandTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(actual.Version, Does.StartWith("0.1.9"));
+            Assert.That(actual.Version, Does.StartWith("0.2.0"));
             Assert.That(actual.Description, Is.EqualTo("A command-line interface for Keystone."));
             Assert.That(actual.Copyright, Is.EqualTo("© 2025 Knight Owl LLC. All rights reserved."));
             Assert.That(actual.DefaultTemplateTarget, Is.EqualTo(defaultTemplateTarget));


### PR DESCRIPTION
## Summary

Prepares for the 0.2.0 release by updating version numbers across all configuration files.

## Changes

- Update version properties in `Keystone.Cli.csproj` (Version, ApplicationVersion, AssemblyVersion, FileVersion, InformationalVersion)
- Update VERSION section in man page
- Update version assertion in unit tests