### PR TITLE
Remove `M:` prefix from cref attributes to fix IDE warnings

### DIFF
--- a/src/Keystone.Cli/Application/FileSystem/IFileSystemService.cs
+++ b/src/Keystone.Cli/Application/FileSystem/IFileSystemService.cs
@@ -25,7 +25,7 @@ public interface IFileSystemService
     /// </summary>
     /// <param name="path">The directory to create.</param>
     /// <returns>An object that represents the directory at the specified path. This object is returned regardless of whether a directory at the specified path already exists.</returns>
-    /// <exception cref="ArgumentException"><paramref name="path" /> is a zero-length string, or contains one or more invalid characters. You can query for invalid characters by using the <see cref="M:System.IO.Path.GetInvalidPathChars" /> method.</exception>
+    /// <exception cref="ArgumentException"><paramref name="path" /> is a zero-length string, or contains one or more invalid characters. You can query for invalid characters by using the <see cref="System.IO.Path.GetInvalidPathChars" /> method.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="path" /> is <see langword="null" />.</exception>
     /// <exception cref="UnauthorizedAccessException">The caller does not have the required permission.</exception>
     /// <exception cref="PathTooLongException">The specified path exceeds the system-defined maximum length.</exception>


### PR DESCRIPTION
## Summary

Eliminates IDE warnings by using simplified cref syntax in XML documentation comments. The `M:` prefix is legacy syntax that modern IDEs flag as unnecessary.

## Related Issues

Fixes #117

## Changes

- Remove `M:` prefix from cref attribute referencing `System.IO.Path.GetInvalidPathChars` in `IFileSystemService.cs`