### PR TITLE
Fix arithmetic expression exit status in test-all.sh

### DIFF
--- a/tests/deb/test-all.sh
+++ b/tests/deb/test-all.sh
@@ -107,7 +107,7 @@ for target in "${BUILD_TARGETS[@]}"; do
 
         if ./tests/deb/test-package.sh "$deb_file" "$image"; then
             echo "PASSED: $rid on $image"
-            ((TESTED++))
+            TESTED=$((TESTED + 1))
         else
             echo "FAILED: $rid on $image"
             FAILED=1


### PR DESCRIPTION
## Summary

Fixes incorrect exit status reporting when running the deb package test script. IDE terminals (such as Rider) would show failure indicators even when all tests passed, due to a bash arithmetic expression quirk.

## Related Issues

Fixes #121

## Changes

- Replace `((TESTED++))` with `TESTED=$((TESTED + 1))` to ensure the increment operation always returns exit status 0

## Testing

Verified by temporarily setting `<InvariantGlobalization>false</InvariantGlobalization>` to break the deb test, then observing correct failure indication in the terminal. After reverting, the terminal correctly shows success.