### PR TITLE
Standardize project description by removing leading article

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Homebrew](https://img.shields.io/badge/install-homebrew-brightgreen)](https://brew.sh)
 [![Apt](https://img.shields.io/badge/install-apt-blue)](https://apt.knight-owl.dev)
 
-A command-line interface for Keystone.
+Command-line interface for Keystone.
 
 - 📦 [Releases](https://github.com/Knight-Owl-Dev/keystone-cli/releases) — binaries & checksums
 - 📄 [License & Notices](NOTICE.md)

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -2,7 +2,7 @@ name: keystone-cli
 arch: "${ARCH}"
 version: "${VERSION}"
 maintainer: "Knight Owl Dev"
-description: "A command-line interface for Keystone"
+description: "Command-line interface for Keystone"
 homepage: "https://github.com/knight-owl-dev/keystone-cli"
 license: "MIT"
 

--- a/src/Keystone.Cli/Keystone.Cli.csproj
+++ b/src/Keystone.Cli/Keystone.Cli.csproj
@@ -10,7 +10,7 @@
         <Authors>Oleksandr Akhtyrskiy</Authors>
         <Company>Knight Owl LLC</Company>
         <Copyright>© 2025 Knight Owl LLC. All rights reserved.</Copyright>
-        <Description>A command-line interface for Keystone.</Description>
+        <Description>Command-line interface for Keystone.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Version>0.2.0</Version>
         <ApplicationVersion>0.2.0</ApplicationVersion>

--- a/tests/Keystone.Cli.UnitTests/Application/Commands/Info/InfoCommandTests.cs
+++ b/tests/Keystone.Cli.UnitTests/Application/Commands/Info/InfoCommandTests.cs
@@ -34,7 +34,7 @@ public class InfoCommandTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(actual.Version, Does.StartWith("0.2.0"));
-            Assert.That(actual.Description, Is.EqualTo("A command-line interface for Keystone."));
+            Assert.That(actual.Description, Is.EqualTo("Command-line interface for Keystone."));
             Assert.That(actual.Copyright, Is.EqualTo("© 2025 Knight Owl LLC. All rights reserved."));
             Assert.That(actual.DefaultTemplateTarget, Is.EqualTo(defaultTemplateTarget));
             Assert.That(actual.TemplateTargets, Is.EqualTo(templateTargets));


### PR DESCRIPTION
## Summary

Standardizes the project description by removing the leading "A" article for consistency across all metadata locations.

## Related Issues

Fixes #123

## Changes

- Update project description from "A command-line interface for Keystone" to "Command-line interface for Keystone" in `nfpm.yaml`, `README.md`, `Keystone.Cli.csproj`, and corresponding test assertion