### PR TITLE
Add automatic Homebrew tap update on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,3 +185,12 @@ jobs:
           repository: knight-owl-dev/apt
           event-type: release-published
           client-payload: '{"versions": "keystone-cli:${{ needs.validate.outputs.version }}"}'
+
+      - name: Trigger Homebrew tap update
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          # Fine-grained PAT scoped to knight-owl-dev/homebrew-tap with Contents: Read and write
+          token: ${{ secrets.HOMEBREW_TAP_REPO_TOKEN }}
+          repository: knight-owl-dev/homebrew-tap
+          event-type: release-published
+          client-payload: '{"formulas": "keystone-cli:${{ needs.validate.outputs.version }}"}'


### PR DESCRIPTION
## Summary

Enables automatic Homebrew formula updates when releases are published. This ensures users can install the latest version via Homebrew shortly after a release, without requiring manual tap updates.

## Related Issues

Fixes #127

## Changes

- Add repository dispatch step to release workflow that triggers knight-owl-dev/homebrew-tap on release-published event
- Pass formula name and version in client payload using same pattern as existing apt repository trigger

## Further Comments

Requires `HOMEBREW_TAP_REPO_TOKEN` secret configured in repository settings (fine-grained PAT scoped to knight-owl-dev/homebrew-tap with Contents: Read and write).