### PR TITLE
Integrate shfmt for shell script formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -595,6 +595,11 @@ resharper_xmldoc_space_before_self_closing = true
 resharper_xmldoc_wrap_tags_and_pi = false
 resharper_xmldoc_wrap_text = true
 
+# Shell scripts
+[*.sh]
+indent_style = space
+indent_size = 2
+shell_variant = bash
 
 [{*.har,*.inputactions,*.jsb2,*.jsb3,*.json,.babelrc,.eslintrc,.stylelintrc,bowerrc,jest.config}]
 indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,17 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup shfmt
+        uses: mfinelli/setup-shfmt@v4
+
+      - name: Check shell script formatting (shfmt)
+        run: shfmt -d -i 2 -ci -bn -sr scripts/ tests/
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,21 @@ The project uses strict code analysis:
 - `TreatWarningsAsErrors` is enabled
 - Extensive .editorconfig with C# and ReSharper rules
 - Uses Microsoft.VisualStudio.Threading.Analyzers
+- Shell scripts use shfmt for formatting (`shfmt -i 2 -ci -bn -sr`)
+
+### Shell Script Formatting
+
+Scripts in `scripts/` and `tests/deb/` are formatted with shfmt:
+
+```bash
+# Check formatting (CI uses this)
+shfmt -d -i 2 -ci -bn -sr scripts/ tests/
+
+# Format in place (local development)
+shfmt -w -i 2 -ci -bn -sr scripts/ tests/
+```
+
+Install shfmt: `brew install shfmt` (macOS) or `go install mvdan.cc/sh/v3/cmd/shfmt@latest`
 
 ### Manual Pages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,7 @@ This project follows a structured workflow documented in
 - The project uses `TreatWarningsAsErrors` — all warnings must be resolved
 - Follow existing code patterns and architecture
 - Include unit tests for new functionality
+- Shell scripts must pass `shfmt` formatting (see [CLAUDE.md](CLAUDE.md) for details)
 - Run `dotnet test` before submitting
 
 ## Labels

--- a/scripts/generate-checksums.sh
+++ b/scripts/generate-checksums.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 #
 # Generate SHA256 checksums for release artifacts.
 #
@@ -25,8 +27,6 @@
 #   1 - No artifacts found or directory not found
 #   2 - Invalid arguments
 #
-
-set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"

--- a/scripts/get-english-month-year.sh
+++ b/scripts/get-english-month-year.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 #
 # Get the current month and year in English format.
 #
@@ -15,8 +17,6 @@
 #   0 - Success
 #   1 - Unexpected error
 #
-
-set -euo pipefail
 
 month_num=$(date '+%m')
 year=$(date '+%Y')

--- a/scripts/get-tfm.sh
+++ b/scripts/get-tfm.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 #
 # Extract the target framework moniker (TFM) from Directory.Build.props.
 #
@@ -15,8 +17,6 @@
 #   0 - Success
 #   1 - Could not read TargetFramework from Directory.Build.props
 #
-
-set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"

--- a/scripts/get-version.sh
+++ b/scripts/get-version.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 #
 # Extract the project version from Keystone.Cli.csproj.
 #
@@ -15,8 +17,6 @@
 #   0 - Success
 #   1 - Could not read Version from csproj
 #
-
-set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 #
 # Create .deb packages for Linux distributions.
 #
@@ -29,8 +31,6 @@
 #   1 - Missing requirements or build failed
 #   2 - Invalid arguments
 #
-
-set -euo pipefail
 
 # Always run relative to the repo root.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -87,7 +87,7 @@ OUT_DIR="artifacts/release"
 mkdir -p "$OUT_DIR"
 
 # Check for nfpm
-if ! command -v nfpm >/dev/null 2>&1; then
+if ! command -v nfpm > /dev/null 2>&1; then
   echo "ERROR: nfpm is not installed." >&2
   echo "Install with: brew install nfpm" >&2
   echo "         or: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest" >&2
@@ -104,7 +104,7 @@ package() {
   # Map RID to Debian architecture (validate-rid.sh --linux restricts values,
   # but we guard against unexpected RIDs for safety)
   case "$RID" in
-    linux-x64)   ARCH="amd64" ;;
+    linux-x64) ARCH="amd64" ;;
     linux-arm64) ARCH="arm64" ;;
     *)
       echo "ERROR: Unexpected RID: $RID" >&2
@@ -147,7 +147,7 @@ package() {
   ARCH="$ARCH" VERSION="$VERSION" RID="$RID" TFM="$TFM" \
     nfpm package --packager deb --target "$PACKAGE"
 
-  if command -v shasum >/dev/null 2>&1; then
+  if command -v shasum > /dev/null 2>&1; then
     shasum -a 256 "$PACKAGE"
   else
     sha256sum "$PACKAGE"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 #
 # Create release tarballs for distribution.
 #
@@ -28,8 +30,6 @@
 #   1 - Missing requirements or build failed
 #   2 - Invalid arguments
 #
-
-set -euo pipefail
 
 # Always run relative to the repo root.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -131,7 +131,7 @@ package() {
     -C "$REPO_ROOT" LICENSE \
     -C "$REPO_ROOT/docs/man/man1" keystone-cli.1
 
-  if command -v shasum >/dev/null 2>&1; then
+  if command -v shasum > /dev/null 2>&1; then
     shasum -a 256 "$ARCHIVE"
   else
     sha256sum "$ARCHIVE"

--- a/scripts/validate-arch.sh
+++ b/scripts/validate-arch.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 #
 # Validate a Debian architecture for safe use in scripts.
 #
@@ -12,22 +14,20 @@
 #   1 - Invalid architecture or missing argument
 #
 
-set -euo pipefail
-
 if [[ $# -ne 1 ]]; then
-    echo "Usage: $(basename "$0") <arch>" >&2
-    exit 1
+  echo "Usage: $(basename "$0") <arch>" >&2
+  exit 1
 fi
 
 ARCH="$1"
 
 case "$ARCH" in
-    amd64|arm64)
-        echo "$ARCH"
-        ;;
-    *)
-        echo "ERROR: Invalid architecture: $ARCH" >&2
-        echo "Supported architectures: amd64, arm64" >&2
-        exit 1
-        ;;
+  amd64 | arm64)
+    echo "$ARCH"
+    ;;
+  *)
+    echo "ERROR: Invalid architecture: $ARCH" >&2
+    echo "Supported architectures: amd64, arm64" >&2
+    exit 1
+    ;;
 esac

--- a/scripts/validate-rid.sh
+++ b/scripts/validate-rid.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 #
 # Validate a .NET runtime identifier (RID) for safe use in scripts.
 #
@@ -17,42 +19,40 @@
 #   1 - Invalid RID or missing argument
 #
 
-set -euo pipefail
-
 LINUX_ONLY=false
 
 if [[ $# -ge 1 && "$1" == "--linux" ]]; then
-    LINUX_ONLY=true
-    shift
+  LINUX_ONLY=true
+  shift
 fi
 
 if [[ $# -ne 1 ]]; then
-    echo "Usage: $(basename "$0") [--linux] <rid>" >&2
-    exit 1
+  echo "Usage: $(basename "$0") [--linux] <rid>" >&2
+  exit 1
 fi
 
 RID="$1"
 
 if [[ "$LINUX_ONLY" == true ]]; then
-    case "$RID" in
-        linux-x64|linux-arm64)
-            echo "$RID"
-            ;;
-        *)
-            echo "ERROR: Invalid Linux RID: $RID" >&2
-            echo "Supported Linux RIDs: linux-x64, linux-arm64" >&2
-            exit 1
-            ;;
-    esac
+  case "$RID" in
+    linux-x64 | linux-arm64)
+      echo "$RID"
+      ;;
+    *)
+      echo "ERROR: Invalid Linux RID: $RID" >&2
+      echo "Supported Linux RIDs: linux-x64, linux-arm64" >&2
+      exit 1
+      ;;
+  esac
 else
-    case "$RID" in
-        osx-arm64|osx-x64|linux-x64|linux-arm64)
-            echo "$RID"
-            ;;
-        *)
-            echo "ERROR: Invalid RID: $RID" >&2
-            echo "Supported RIDs: osx-arm64, osx-x64, linux-x64, linux-arm64" >&2
-            exit 1
-            ;;
-    esac
+  case "$RID" in
+    osx-arm64 | osx-x64 | linux-x64 | linux-arm64)
+      echo "$RID"
+      ;;
+    *)
+      echo "ERROR: Invalid RID: $RID" >&2
+      echo "Supported RIDs: osx-arm64, osx-x64, linux-x64, linux-arm64" >&2
+      exit 1
+      ;;
+  esac
 fi

--- a/scripts/validate-version.sh
+++ b/scripts/validate-version.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 #
 # Validate a version string for safe use in filenames and shell commands.
 #
@@ -13,11 +15,9 @@
 #   1 - Invalid version or missing argument
 #
 
-set -euo pipefail
-
 if [[ $# -ne 1 ]]; then
-    echo "Usage: $(basename "$0") <version>" >&2
-    exit 1
+  echo "Usage: $(basename "$0") <version>" >&2
+  exit 1
 fi
 
 VERSION="$1"
@@ -25,9 +25,9 @@ VERSION="$1"
 # Semver pattern: MAJOR.MINOR.PATCH with optional -prerelease.identifier
 # Allows: 1.0.0, 0.2.0, 1.0.0-beta.1, 2.0.0-rc.1, 1.0.0-alpha
 if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$ ]]; then
-    echo "ERROR: Invalid version format: $VERSION" >&2
-    echo "Expected: MAJOR.MINOR.PATCH (e.g., 1.0.0) or MAJOR.MINOR.PATCH-prerelease (e.g., 1.0.0-beta.1)" >&2
-    exit 1
+  echo "ERROR: Invalid version format: $VERSION" >&2
+  echo "Expected: MAJOR.MINOR.PATCH (e.g., 1.0.0) or MAJOR.MINOR.PATCH-prerelease (e.g., 1.0.0-beta.1)" >&2
+  exit 1
 fi
 
 echo "$VERSION"

--- a/scripts/verify-deb-install.sh
+++ b/scripts/verify-deb-install.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 #
 # Verify a .deb package installs and runs correctly.
 #
@@ -13,19 +15,17 @@
 #   1 - Verification failed or invalid arguments
 #
 
-set -euo pipefail
-
 if [[ $# -ne 1 ]]; then
-    echo "Usage: $0 <path-to-deb>"
-    echo "Error: Expected exactly 1 argument, got $#"
-    exit 1
+  echo "Usage: $0 <path-to-deb>"
+  echo "Error: Expected exactly 1 argument, got $#"
+  exit 1
 fi
 
 DEB_FILE="$1"
 
 if [[ ! -f "$DEB_FILE" ]]; then
-    echo "ERROR: File not found: $DEB_FILE"
-    exit 1
+  echo "ERROR: File not found: $DEB_FILE"
+  exit 1
 fi
 
 echo "=== Installing dependencies ==="

--- a/tests/deb/test-all.sh
+++ b/tests/deb/test-all.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 #
 # Build and test all .deb packages locally.
 #
@@ -22,8 +24,6 @@
 #   - Cross-architecture testing requires QEMU emulation (slow)
 #
 
-set -eo pipefail
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
@@ -32,10 +32,22 @@ cd "$REPO_ROOT"
 # Detect host architecture
 HOST_ARCH=$(uname -m)
 case "$HOST_ARCH" in
-    x86_64)  HOST_DEB_ARCH="amd64"; HOST_RID="linux-x64" ;;
-    aarch64) HOST_DEB_ARCH="arm64"; HOST_RID="linux-arm64" ;;
-    arm64)   HOST_DEB_ARCH="arm64"; HOST_RID="linux-arm64" ;;
-    *) echo "Unknown host architecture: $HOST_ARCH"; exit 1 ;;
+  x86_64)
+    HOST_DEB_ARCH="amd64"
+    HOST_RID="linux-x64"
+    ;;
+  aarch64)
+    HOST_DEB_ARCH="arm64"
+    HOST_RID="linux-arm64"
+    ;;
+  arm64)
+    HOST_DEB_ARCH="arm64"
+    HOST_RID="linux-arm64"
+    ;;
+  *)
+    echo "Unknown host architecture: $HOST_ARCH"
+    exit 1
+    ;;
 esac
 
 # Get version from csproj
@@ -46,8 +58,8 @@ echo "==========================================="
 
 # Define build targets: RID|arch
 BUILD_TARGETS=(
-    "linux-x64|amd64"
-    "linux-arm64|arm64"
+  "linux-x64|amd64"
+  "linux-arm64|arm64"
 )
 
 # Test images to use
@@ -58,15 +70,15 @@ echo ""
 echo "=== Building packages ==="
 
 for target in "${BUILD_TARGETS[@]}"; do
-    rid="${target%%|*}"
-    echo ""
-    echo "--- Building $rid ---"
+  rid="${target%%|*}"
+  echo ""
+  echo "--- Building $rid ---"
 
-    echo "Publishing..."
-    dotnet publish ./src/Keystone.Cli/Keystone.Cli.csproj -c Release -r "$rid" -v quiet
+  echo "Publishing..."
+  dotnet publish ./src/Keystone.Cli/Keystone.Cli.csproj -c Release -r "$rid" -v quiet
 
-    echo "Packaging .deb..."
-    ./scripts/package-deb.sh "$VERSION" "$rid"
+  echo "Packaging .deb..."
+  ./scripts/package-deb.sh "$VERSION" "$rid"
 done
 
 echo ""
@@ -81,55 +93,55 @@ FAILED=0
 TESTED=0
 
 for target in "${BUILD_TARGETS[@]}"; do
-    rid="${target%%|*}"
-    arch="${target##*|}"
+  rid="${target%%|*}"
+  arch="${target##*|}"
 
-    deb_file="artifacts/release/keystone-cli_${VERSION}_${arch}.deb"
+  deb_file="artifacts/release/keystone-cli_${VERSION}_${arch}.deb"
 
-    if [[ ! -f "$deb_file" ]]; then
-        echo "ERROR: Package not found: $deb_file"
-        FAILED=1
-        continue
+  if [[ ! -f "$deb_file" ]]; then
+    echo "ERROR: Package not found: $deb_file"
+    FAILED=1
+    continue
+  fi
+
+  # Check if we can test this architecture
+  if [[ "$arch" != "$HOST_DEB_ARCH" ]]; then
+    echo ""
+    echo "--- Skipping $deb_file (requires $arch, host is $HOST_DEB_ARCH) ---"
+    echo "    To test cross-architecture, use QEMU emulation."
+    continue
+  fi
+
+  # Test on each image
+  for image in $TEST_IMAGES; do
+    echo ""
+    echo "--- Testing $deb_file on $image ---"
+
+    if ./tests/deb/test-package.sh "$deb_file" "$image"; then
+      echo "PASSED: $rid on $image"
+      TESTED=$((TESTED + 1))
+    else
+      echo "FAILED: $rid on $image"
+      FAILED=1
     fi
-
-    # Check if we can test this architecture
-    if [[ "$arch" != "$HOST_DEB_ARCH" ]]; then
-        echo ""
-        echo "--- Skipping $deb_file (requires $arch, host is $HOST_DEB_ARCH) ---"
-        echo "    To test cross-architecture, use QEMU emulation."
-        continue
-    fi
-
-    # Test on each image
-    for image in $TEST_IMAGES; do
-        echo ""
-        echo "--- Testing $deb_file on $image ---"
-
-        if ./tests/deb/test-package.sh "$deb_file" "$image"; then
-            echo "PASSED: $rid on $image"
-            TESTED=$((TESTED + 1))
-        else
-            echo "FAILED: $rid on $image"
-            FAILED=1
-        fi
-    done
+  done
 done
 
 echo ""
 echo "==========================================="
 
 if [[ $TESTED -eq 0 ]]; then
-    echo "WARNING: No packages were tested."
-    echo "Built packages (untested):"
-    ls artifacts/release/*.deb
-    exit 1
+  echo "WARNING: No packages were tested."
+  echo "Built packages (untested):"
+  ls artifacts/release/*.deb
+  exit 1
 elif [[ $FAILED -eq 0 ]]; then
-    echo "All tests passed! ($TESTED tests)"
-    echo ""
-    echo "Packages ready for release:"
-    ls artifacts/release/*.deb
-    exit 0
+  echo "All tests passed! ($TESTED tests)"
+  echo ""
+  echo "Packages ready for release:"
+  ls artifacts/release/*.deb
+  exit 0
 else
-    echo "Some tests failed. Check output above."
-    exit 1
+  echo "Some tests failed. Check output above."
+  exit 1
 fi

--- a/tests/deb/test-package.sh
+++ b/tests/deb/test-package.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 #
 # Test a locally-built .deb package in a Docker container.
 #
@@ -23,26 +25,24 @@
 #   1 - Test failed or invalid arguments
 #
 
-set -euo pipefail
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 if [[ $# -lt 1 ]]; then
-    echo "Usage: $0 <path-to-deb> [image]"
-    echo ""
-    echo "Examples:"
-    echo "  $0 artifacts/release/keystone-cli_0.1.10_amd64.deb"
-    echo "  $0 artifacts/release/keystone-cli_0.1.10_arm64.deb ubuntu:24.04"
-    exit 1
+  echo "Usage: $0 <path-to-deb> [image]"
+  echo ""
+  echo "Examples:"
+  echo "  $0 artifacts/release/keystone-cli_0.1.10_amd64.deb"
+  echo "  $0 artifacts/release/keystone-cli_0.1.10_arm64.deb ubuntu:24.04"
+  exit 1
 fi
 
 DEB_FILE="$1"
 IMAGE="${2:-debian:bookworm-slim}"
 
 if [[ ! -f "$DEB_FILE" ]]; then
-    echo "ERROR: File not found: $DEB_FILE"
-    exit 1
+  echo "ERROR: File not found: $DEB_FILE"
+  exit 1
 fi
 
 DEB_DIR="$(cd "$(dirname "$DEB_FILE")" && pwd)"
@@ -53,7 +53,7 @@ echo "Image: $IMAGE"
 echo "==========================================="
 
 docker run --rm \
-    -v "$DEB_DIR:/deb:ro" \
-    -v "$REPO_ROOT/scripts:/scripts:ro" \
-    "$IMAGE" \
-    bash /scripts/verify-deb-install.sh "/deb/$DEB_FILENAME"
+  -v "$DEB_DIR:/deb:ro" \
+  -v "$REPO_ROOT/scripts:/scripts:ro" \
+  "$IMAGE" \
+  bash /scripts/verify-deb-install.sh "/deb/$DEB_FILENAME"


### PR DESCRIPTION
## Summary

Add shfmt enforcement to ensure consistent shell script formatting across the repository. This eliminates style discussions in PRs, catches syntax issues early, and improves maintainability of scripts in `scripts/` and `tests/deb/`.

## Related Issues

Fixes #129

## Changes

- Format all 12 shell scripts with shfmt (`-i 2 -ci -bn -sr`)
- Standardize `set -euo pipefail` placement immediately after shebang
- Add `[*.sh]` section to `.editorconfig` for editor support
- Add `lint` CI job to enforce formatting on PRs
- Document shfmt usage in CLAUDE.md and CONTRIBUTING.md