### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/docs/man/man1/keystone-cli.1
+++ b/docs/man/man1/keystone-cli.1
@@ -225,7 +225,7 @@ executable.
 .El
 
 .Sh VERSION
-keystone-cli 0.2.1
+keystone-cli 0.2.2
 
 .Sh AUTHOR
 Knight Owl LLC

--- a/src/Keystone.Cli/Keystone.Cli.csproj
+++ b/src/Keystone.Cli/Keystone.Cli.csproj
@@ -12,11 +12,11 @@
         <Copyright>© 2025 Knight Owl LLC. All rights reserved.</Copyright>
         <Description>Command-line interface for Keystone.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>0.2.1</Version>
-        <ApplicationVersion>0.2.1</ApplicationVersion>
-        <AssemblyVersion>0.2.1</AssemblyVersion>
-        <FileVersion>0.2.1</FileVersion>
-        <InformationalVersion>0.2.1</InformationalVersion>
+        <Version>0.2.2</Version>
+        <ApplicationVersion>0.2.2</ApplicationVersion>
+        <AssemblyVersion>0.2.2</AssemblyVersion>
+        <FileVersion>0.2.2</FileVersion>
+        <InformationalVersion>0.2.2</InformationalVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/tests/Keystone.Cli.UnitTests/Application/Commands/Info/InfoCommandTests.cs
+++ b/tests/Keystone.Cli.UnitTests/Application/Commands/Info/InfoCommandTests.cs
@@ -33,7 +33,7 @@ public class InfoCommandTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(actual.Version, Does.StartWith("0.2.1"));
+            Assert.That(actual.Version, Does.StartWith("0.2.2"));
             Assert.That(actual.Description, Is.EqualTo("Command-line interface for Keystone."));
             Assert.That(actual.Copyright, Is.EqualTo("© 2025 Knight Owl LLC. All rights reserved."));
             Assert.That(actual.DefaultTemplateTarget, Is.EqualTo(defaultTemplateTarget));


### PR DESCRIPTION
## Summary

Bump the project version to 0.2.2 in preparation for the next release.

## Changes

- Update all version properties in `Keystone.Cli.csproj` to 0.2.2
- Update VERSION section in the man page to 0.2.2
- Update version assertion in `InfoCommandTests` to match