### PR TITLE
Replace Task.FromResult with NSubstitute shorthand in GitHubServiceTests

### DIFF
--- a/tests/Keystone.Cli.UnitTests/Application/GitHub/GitHubServiceTests.cs
+++ b/tests/Keystone.Cli.UnitTests/Application/GitHub/GitHubServiceTests.cs
@@ -118,7 +118,7 @@ public class GitHubServiceTests
 
         gitHubZipEntryCollectionFactory
             .CreateAsync(repositoryUrl, branchName, cancellationToken)
-            .Returns(Task.FromResult(entryCollection));
+            .Returns(entryCollection);
 
         var sut = Ctor(
             fileSystemCopyService: fileSystemCopyService,
@@ -133,11 +133,9 @@ public class GitHubServiceTests
             cancellationToken: cancellationToken
         );
 
-        fileSystemCopyService.Received(1).Copy(
-            entryCollection,
-            destinationPath,
-            overwrite: false
-        );
+        fileSystemCopyService
+            .Received(1)
+            .Copy(entryCollection, destinationPath, overwrite: false);
     }
 
     [Test]
@@ -153,7 +151,7 @@ public class GitHubServiceTests
 
         gitHubZipEntryCollectionFactory
             .CreateAsync(repositoryUrl, branchName, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(entryCollection));
+            .Returns(entryCollection);
 
         var sut = Ctor(
             fileSystemCopyService: fileSystemCopyService,
@@ -183,7 +181,7 @@ public class GitHubServiceTests
 
         gitHubZipEntryCollectionFactory
             .CreateAsync(repositoryUrl, branchName, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(entryCollection));
+            .Returns(entryCollection);
 
         var sut = Ctor(
             fileSystemCopyService: fileSystemCopyService,
@@ -197,11 +195,9 @@ public class GitHubServiceTests
             overwrite: true
         );
 
-        fileSystemCopyService.Received(1).Copy(
-            entryCollection,
-            destinationPath,
-            overwrite: true
-        );
+        fileSystemCopyService
+            .Received(1)
+            .Copy(entryCollection, destinationPath, overwrite: true);
     }
 
     [Test]
@@ -218,7 +214,7 @@ public class GitHubServiceTests
 
         gitHubZipEntryCollectionFactory
             .CreateAsync(repositoryUrl, branchName, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(entryCollection));
+            .Returns(entryCollection);
 
         var sut = Ctor(
             fileSystemCopyService: fileSystemCopyService,
@@ -233,11 +229,8 @@ public class GitHubServiceTests
             predicate: predicate
         );
 
-        fileSystemCopyService.Received(1).Copy(
-            entryCollection,
-            destinationPath,
-            overwrite: false,
-            predicate
-        );
+        fileSystemCopyService
+            .Received(1)
+            .Copy(entryCollection, destinationPath, overwrite: false, predicate);
     }
 }


### PR DESCRIPTION
## Summary

Resolves CA2025 analyzer warnings ("Do not pass `IDisposable` instances into unawaited tasks") by using NSubstitute's native `Task<T>` unwrapping instead of explicitly wrapping return values with `Task.FromResult()`.

## Related Issues

Fixes #150

## Changes

- Replace `.Returns(Task.FromResult(entryCollection))` with `.Returns(entryCollection)` in all four test methods in `GitHubServiceTests.cs`