### PR TITLE
Switch CI workflow to use internal ci-tools image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,39 +10,21 @@ permissions:
   contents: read
 
 jobs:
-  lint:
+  lint-dotnet:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
       - uses: ./.github/actions/setup-dotnet
-
       - name: Check C# formatting (dotnet format)
         run: dotnet format --verify-no-changes
 
-      - name: Setup actionlint
-        uses: raven-actions/actionlint@v2
-
-      - name: Setup shfmt
-        uses: mfinelli/setup-shfmt@v4
-
-      - name: Check shell script formatting (shfmt)
-        run: shfmt -d -i 2 -ci -bn -sr scripts/ tests/
-
-      - name: Check shell scripts (shellcheck)
-        run: find scripts tests -name '*.sh' -type f -exec shellcheck --severity=warning {} +
-
-      - name: Check GitHub Actions workflows (actionlint)
-        run: actionlint
-
-      - name: Check Markdown files (markdownlint)
-        uses: DavidAnson/markdownlint-cli2-action@v22
-        with:
-          globs: |
-            *.md
-            docs/**/*.md
-            .github/**/*.md
-            .claude/**/*.md
+  lint:
+    runs-on: ubuntu-latest
+    container: ghcr.io/knight-owl-dev/ci-tools:latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Lint
+        run: make lint SKIP=lint-dotnet
 
   test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,14 @@
 # Shell scripts to lint (all .sh files in scripts/ and tests/)
 SHELL_SCRIPTS := $(shell find scripts tests -name '*.sh' -type f)
 
-# shfmt flags (must match ci.yml)
+# shfmt flags (ci.yml delegates to this target)
 SHFMT_FLAGS := -i 2 -ci -bn -sr
+
+# All lint targets (order matches local developer workflow)
+LINT_TARGETS := lint-dotnet lint-shfmt lint-shellcheck lint-actionlint lint-markdown
+
+# Exclude specific targets: make lint SKIP=lint-dotnet
+SKIP :=
 
 help: ## Show available targets
 	@echo "Usage: make [target]"
@@ -24,36 +30,43 @@ help: ## Show available targets
 man: ## View the man page
 	@mandoc docs/man/man1/keystone-cli.1
 
-lint: lint-dotnet lint-shfmt lint-shellcheck lint-actionlint lint-markdown ## Run all linters
-	@echo "All checks passed"
+lint: $(filter-out $(SKIP),$(LINT_TARGETS)) ## Run all linters
 
 lint-fix: lint-dotnet-fix lint-shfmt-fix ## Auto-fix formatting issues
 	@echo "Note: shellcheck and markdownlint issues must be fixed manually"
+	@echo "OK"
 
 lint-dotnet: ## Check C# code formatting
 	@echo "Checking C# formatting (dotnet format)..."
 	@dotnet format --verify-no-changes
+	@echo "OK"
 
 lint-dotnet-fix: ## Fix C# code formatting
 	@echo "Fixing C# formatting (dotnet format)..."
 	@dotnet format
+	@echo "OK"
 
 lint-shfmt: ## Check shell script formatting
 	@echo "Checking shell script formatting (shfmt)..."
 	@shfmt -d $(SHFMT_FLAGS) $(SHELL_SCRIPTS)
+	@echo "OK"
 
 lint-shfmt-fix: ## Fix shell script formatting
 	@echo "Fixing shell script formatting (shfmt)..."
 	@shfmt -w $(SHFMT_FLAGS) $(SHELL_SCRIPTS)
+	@echo "OK"
 
 lint-shellcheck: ## Run shellcheck on shell scripts
 	@echo "Running shellcheck..."
 	@shellcheck --severity=warning $(SHELL_SCRIPTS)
+	@echo "OK"
 
 lint-actionlint: ## Validate GitHub Actions workflows
 	@echo "Checking GitHub Actions workflows (actionlint)..."
-	@actionlint
+	@actionlint .github/workflows/*.yml
+	@echo "OK"
 
 lint-markdown: ## Check Markdown file formatting
 	@echo "Checking Markdown files (markdownlint)..."
 	@markdownlint-cli2 "*.md" "docs/**/*.md" ".github/**/*.md" ".claude/**/*.md"
+	@echo "OK"


### PR DESCRIPTION
## Summary

Migrate the CI lint job to use the internal `ghcr.io/knight-owl-dev/ci-tools:latest` container image, replacing three third-party GitHub Actions (`raven-actions/actionlint`, `mfinelli/setup-shfmt`, `DavidAnson/markdownlint-cli2-action`) with tools bundled in the shared image. This improves consistency with other projects and reduces the CI supply-chain attack surface.

## Related Issues

Fixes #152

## Changes

- Split the monolithic `lint` job into parallel `lint-dotnet` (needs .NET SDK on `ubuntu-latest`) and `lint` (runs in ci-tools container) jobs
- Add `SKIP` variable to Makefile using `filter-out` so CI can exclude targets with `make lint SKIP=lint-dotnet`
- Remove third-party actions: `raven-actions/actionlint@v2`, `mfinelli/setup-shfmt@v4`, `DavidAnson/markdownlint-cli2-action@v22`
- Pass explicit workflow paths to `actionlint` for container compatibility
- Add `OK` echo to each Makefile lint target (devops convention)