### PR TITLE
Delegate lint-dotnet CI job to Makefile target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-dotnet
-      - name: Check C# formatting (dotnet format)
-        run: dotnet format --verify-no-changes
+      - name: Lint
+        run: make lint-dotnet
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Both CI lint jobs now delegate to Makefile targets, keeping the workflow file minimal and ensuring CI and local linting stay in sync automatically.

## Related Issues

Fixes #154

## Changes

- Replace inline `dotnet format --verify-no-changes` in the `lint-dotnet` CI job with `make lint-dotnet`