### PR TITLE
Enable lint-mandoc in CI lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Lint
-        run: make lint SKIP="lint-dotnet lint-mandoc"
+        run: make lint SKIP="lint-dotnet"
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Enable man page linting in CI now that the ci-tools container image includes mandoc. Previously excluded in #153 because the image lacked the tool.

## Related Issues

Fixes #159

## Changes

- Remove `lint-mandoc` from the `SKIP` list in the CI lint job