### PR TITLE
Refactor shell scripts to use concise output and enforce variable braces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@
 #   make lint       Run all linters
 #   make lint-fix   Auto-fix shell script formatting
 
-.PHONY: help man lint lint-fix lint-dotnet lint-dotnet-fix lint-shfmt lint-shfmt-fix lint-shellcheck lint-actionlint lint-markdown lint-mandoc
+.PHONY: help man lint lint-fix lint-dotnet lint-dotnet-fix lint-shfmt lint-shfmt-fix \
+	lint-shellcheck lint-actionlint lint-markdown lint-mandoc test-package
 
 .DEFAULT_GOAL := help
 
@@ -58,7 +59,7 @@ lint-shfmt-fix: ## Fix shell script formatting
 
 lint-shellcheck: ## Run shellcheck on shell scripts
 	@echo "Running shellcheck..."
-	@shellcheck --severity=warning $(SHELL_SCRIPTS)
+	@shellcheck --severity=style $(SHELL_SCRIPTS)
 	@echo "OK"
 
 lint-actionlint: ## Validate GitHub Actions workflows
@@ -68,8 +69,11 @@ lint-actionlint: ## Validate GitHub Actions workflows
 
 lint-markdown: ## Check Markdown file formatting
 	@echo "Checking Markdown files (markdownlint)..."
-	@markdownlint-cli2 "*.md" "docs/**/*.md" ".github/**/*.md" ".claude/**/*.md"
+	@markdownlint-cli2 "**/*.md"
 	@echo "OK"
 
 lint-mandoc: ## Lint man pages (mandoc)
 	@echo "Linting man pages..." && mandoc -W warning docs/man/man1/*.1 > /dev/null && echo "OK"
+
+test-package: ## Build and test deb package locally
+	@./tests/deb/test-all.sh

--- a/scripts/generate-checksums.sh
+++ b/scripts/generate-checksums.sh
@@ -70,38 +70,40 @@ fi
 cd "${REPO_ROOT}"
 
 # Default uses repo-relative path
-if [[ -z "$DIST_DIR" ]]; then
-  DIST_DIR="$REPO_ROOT/artifacts/release"
-  if [[ ! -d "$DIST_DIR" ]]; then
-    echo "ERROR: Directory not found: $DIST_DIR" >&2
+if [[ -z "${DIST_DIR}" ]]; then
+  DIST_DIR="${REPO_ROOT}/artifacts/release"
+  if [[ ! -d "${DIST_DIR}" ]]; then
+    echo "ERROR: Directory not found: ${DIST_DIR}" >&2
     exit 1
   fi
 fi
 
 OUT_DIR="artifacts/release"
 
-mkdir -p "$OUT_DIR"
+mkdir -p "${OUT_DIR}"
 
 # Find all release files (.tar.gz and .deb)
-files=$(cd "$DIST_DIR" && find . -maxdepth 3 -type f \( -name '*.tar.gz' -o -name '*.deb' \) -print | sed 's|^\./||')
+files=$(cd "${DIST_DIR}" && find . -maxdepth 3 -type f \( -name '*.tar.gz' -o -name '*.deb' \) -print | sed 's|^\./||')
 
-if [[ -z "$files" ]]; then
-  echo "ERROR: No release files found under $DIST_DIR/" >&2
+if [[ -z "${files}" ]]; then
+  echo "ERROR: No release files found under ${DIST_DIR}/" >&2
   exit 1
 fi
 
 echo "Release assets:"
-echo "$files" | sort
+echo "${files}" | sort
 
 # Compute checksums in GNU coreutils format (checksum first, compatible with sha256sum -c)
 # Output uses basenames only for cleaner checksums.txt
-(cd "$DIST_DIR" && sha256sum $files) | while read -r sum file; do
-  echo "$sum  $(basename "$file")"
-done | sort > "$OUT_DIR/checksums.txt"
+# Intentional word splitting on file list
+# shellcheck disable=SC2086
+(cd "${DIST_DIR}" && sha256sum ${files}) | while read -r sum file; do
+  echo "${sum}  $(basename "${file}")"
+done | sort > "${OUT_DIR}/checksums.txt"
 
 echo ""
-echo "$OUT_DIR/checksums.txt:"
-cat "$OUT_DIR/checksums.txt"
+echo "${OUT_DIR}/checksums.txt:"
+cat "${OUT_DIR}/checksums.txt"
 
 # Generate release body with markdown-formatted checksums
 {
@@ -109,13 +111,13 @@ cat "$OUT_DIR/checksums.txt"
   echo "## SHA256 Checksums"
   echo ""
   echo '```'
-  cat "$OUT_DIR/checksums.txt"
+  cat "${OUT_DIR}/checksums.txt"
   echo '```'
-} > "$OUT_DIR/release-body.md"
+} > "${OUT_DIR}/release-body.md"
 
 echo ""
-echo "$OUT_DIR/release-body.md:"
-cat "$OUT_DIR/release-body.md"
+echo "${OUT_DIR}/release-body.md:"
+cat "${OUT_DIR}/release-body.md"
 
 echo ""
 echo "Done."

--- a/scripts/get-english-month-year.sh
+++ b/scripts/get-english-month-year.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 month_num=$(date '+%m')
 year=$(date '+%Y')
 
-case "$month_num" in
+case "${month_num}" in
   01) month_name="January" ;;
   02) month_name="February" ;;
   03) month_name="March" ;;
@@ -36,7 +36,7 @@ case "$month_num" in
   11) month_name="November" ;;
   12) month_name="December" ;;
   *)
-    echo "ERROR: Unexpected month number: $month_num" >&2
+    echo "ERROR: Unexpected month number: ${month_num}" >&2
     exit 1
     ;;
 esac

--- a/scripts/get-tfm.sh
+++ b/scripts/get-tfm.sh
@@ -21,13 +21,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-PROPS_PATH="$REPO_ROOT/Directory.Build.props"
+PROPS_PATH="${REPO_ROOT}/Directory.Build.props"
 
-TFM="$(sed -n 's:.*<TargetFramework>\(.*\)</TargetFramework>.*:\1:p' "$PROPS_PATH" | head -n 1)"
+TFM="$(sed -n 's:.*<TargetFramework>\(.*\)</TargetFramework>.*:\1:p' "${PROPS_PATH}" | head -n 1)"
 
-if [[ -z "$TFM" ]]; then
-  echo "ERROR: Could not read <TargetFramework> from $PROPS_PATH" >&2
+if [[ -z "${TFM}" ]]; then
+  echo "ERROR: Could not read <TargetFramework> from ${PROPS_PATH}" >&2
   exit 1
 fi
 
-echo "$TFM"
+echo "${TFM}"

--- a/scripts/get-version.sh
+++ b/scripts/get-version.sh
@@ -21,13 +21,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-CSPROJ_PATH="$REPO_ROOT/src/Keystone.Cli/Keystone.Cli.csproj"
+CSPROJ_PATH="${REPO_ROOT}/src/Keystone.Cli/Keystone.Cli.csproj"
 
-VERSION="$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' "$CSPROJ_PATH" | head -n 1)"
+VERSION="$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' "${CSPROJ_PATH}" | head -n 1)"
 
-if [[ -z "$VERSION" ]]; then
-  echo "ERROR: Could not read <Version> from $CSPROJ_PATH" >&2
+if [[ -z "${VERSION}" ]]; then
+  echo "ERROR: Could not read <Version> from ${CSPROJ_PATH}" >&2
   exit 1
 fi
 
-echo "$VERSION"
+echo "${VERSION}"

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -75,16 +75,16 @@ fi
 
 TFM="$("${SCRIPT_DIR}/get-tfm.sh")"
 
-if [[ -z "$VERSION" ]]; then
+if [[ -z "${VERSION}" ]]; then
   VERSION="$("${SCRIPT_DIR}/get-version.sh")"
 fi
 
 # Validate version format for safe use in filenames
-VERSION="$("${SCRIPT_DIR}/validate-version.sh" "$VERSION")"
+VERSION="$("${SCRIPT_DIR}/validate-version.sh" "${VERSION}")"
 
 OUT_DIR="artifacts/release"
 
-mkdir -p "$OUT_DIR"
+mkdir -p "${OUT_DIR}"
 
 # Check for nfpm
 if ! command -v nfpm > /dev/null 2>&1; then
@@ -99,34 +99,34 @@ package() {
   local ARCH
 
   # Validate RID (--linux restricts to linux-x64, linux-arm64)
-  RID="$("${SCRIPT_DIR}/validate-rid.sh" --linux "$RID")"
+  RID="$("${SCRIPT_DIR}/validate-rid.sh" --linux "${RID}")"
 
   # Map RID to Debian architecture (validate-rid.sh --linux restricts values,
   # but we guard against unexpected RIDs for safety)
-  case "$RID" in
+  case "${RID}" in
     linux-x64) ARCH="amd64" ;;
     linux-arm64) ARCH="arm64" ;;
     *)
-      echo "ERROR: Unexpected RID: $RID" >&2
+      echo "ERROR: Unexpected RID: ${RID}" >&2
       exit 1
       ;;
   esac
 
   local PUBLISH_DIR="artifacts/bin/Keystone.Cli/Release/${TFM}/${RID}/publish"
 
-  if [[ ! -d "$PUBLISH_DIR" ]]; then
-    echo "ERROR: Publish directory not found: $PUBLISH_DIR" >&2
-    echo "Run: dotnet publish ./src/Keystone.Cli/Keystone.Cli.csproj -c Release -r $RID" >&2
+  if [[ ! -d "${PUBLISH_DIR}" ]]; then
+    echo "ERROR: Publish directory not found: ${PUBLISH_DIR}" >&2
+    echo "Run: dotnet publish ./src/Keystone.Cli/Keystone.Cli.csproj -c Release -r ${RID}" >&2
     exit 1
   fi
 
-  if [[ ! -f "$PUBLISH_DIR/keystone-cli" ]]; then
-    echo "ERROR: Expected binary not found: $PUBLISH_DIR/keystone-cli" >&2
+  if [[ ! -f "${PUBLISH_DIR}/keystone-cli" ]]; then
+    echo "ERROR: Expected binary not found: ${PUBLISH_DIR}/keystone-cli" >&2
     exit 1
   fi
 
-  if [[ ! -f "$PUBLISH_DIR/appsettings.json" ]]; then
-    echo "ERROR: Expected config not found: $PUBLISH_DIR/appsettings.json" >&2
+  if [[ ! -f "${PUBLISH_DIR}/appsettings.json" ]]; then
+    echo "ERROR: Expected config not found: ${PUBLISH_DIR}/appsettings.json" >&2
     exit 1
   fi
 
@@ -144,21 +144,21 @@ package() {
 
   echo "Building ${PACKAGE} (RID: ${RID}, ARCH: ${ARCH})"
 
-  ARCH="$ARCH" VERSION="$VERSION" RID="$RID" TFM="$TFM" \
-    nfpm package --packager deb --target "$PACKAGE"
+  ARCH="${ARCH}" VERSION="${VERSION}" RID="${RID}" TFM="${TFM}" \
+    nfpm package --packager deb --target "${PACKAGE}"
 
   if command -v shasum > /dev/null 2>&1; then
-    shasum -a 256 "$PACKAGE"
+    shasum -a 256 "${PACKAGE}"
   else
-    sha256sum "$PACKAGE"
+    sha256sum "${PACKAGE}"
   fi
 }
 
-if [[ -n "$RID" ]]; then
-  package "$RID"
+if [[ -n "${RID}" ]]; then
+  package "${RID}"
 else
   package linux-x64
   package linux-arm64
 fi
 
-echo "Done."
+echo "OK"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -76,38 +76,38 @@ fi
 
 TFM="$("${SCRIPT_DIR}/get-tfm.sh")"
 
-if [[ -z "$VERSION" ]]; then
+if [[ -z "${VERSION}" ]]; then
   VERSION="$("${SCRIPT_DIR}/get-version.sh")"
 fi
 
 # Validate version format for safe use in filenames
-VERSION="$("${SCRIPT_DIR}/validate-version.sh" "$VERSION")"
+VERSION="$("${SCRIPT_DIR}/validate-version.sh" "${VERSION}")"
 
 OUT_DIR="artifacts/release"
 
-mkdir -p "$OUT_DIR"
+mkdir -p "${OUT_DIR}"
 
 package() {
   local RID="$1"
 
   # Validate RID format for safe use in paths
-  RID="$("${SCRIPT_DIR}/validate-rid.sh" "$RID")"
+  RID="$("${SCRIPT_DIR}/validate-rid.sh" "${RID}")"
 
   local PUBLISH_DIR="artifacts/bin/Keystone.Cli/Release/${TFM}/${RID}/publish"
 
-  if [[ ! -d "$PUBLISH_DIR" ]]; then
-    echo "ERROR: Publish directory not found: $PUBLISH_DIR" >&2
-    echo "Run: dotnet publish ./src/Keystone.Cli/Keystone.Cli.csproj -c Release -r $RID" >&2
+  if [[ ! -d "${PUBLISH_DIR}" ]]; then
+    echo "ERROR: Publish directory not found: ${PUBLISH_DIR}" >&2
+    echo "Run: dotnet publish ./src/Keystone.Cli/Keystone.Cli.csproj -c Release -r ${RID}" >&2
     exit 1
   fi
 
-  if [[ ! -f "$PUBLISH_DIR/keystone-cli" ]]; then
-    echo "ERROR: Expected binary not found: $PUBLISH_DIR/keystone-cli" >&2
+  if [[ ! -f "${PUBLISH_DIR}/keystone-cli" ]]; then
+    echo "ERROR: Expected binary not found: ${PUBLISH_DIR}/keystone-cli" >&2
     exit 1
   fi
 
-  if [[ ! -f "$PUBLISH_DIR/appsettings.json" ]]; then
-    echo "ERROR: Expected config not found: $PUBLISH_DIR/appsettings.json" >&2
+  if [[ ! -f "${PUBLISH_DIR}/appsettings.json" ]]; then
+    echo "ERROR: Expected config not found: ${PUBLISH_DIR}/appsettings.json" >&2
     exit 1
   fi
 
@@ -135,23 +135,23 @@ package() {
 
   echo "Packaging ${ARCHIVE} (RID: ${RID})"
 
-  tar -C "$PUBLISH_DIR" \
-    -czf "$ARCHIVE" \
+  tar -C "${PUBLISH_DIR}" \
+    -czf "${ARCHIVE}" \
     keystone-cli \
     appsettings.json \
-    -C "$REPO_ROOT" LICENSE \
-    -C "$REPO_ROOT/artifacts/completions" keystone-cli.bash _keystone-cli \
-    -C "$REPO_ROOT/docs/man/man1" keystone-cli.1
+    -C "${REPO_ROOT}" LICENSE \
+    -C "${REPO_ROOT}/artifacts/completions" keystone-cli.bash _keystone-cli \
+    -C "${REPO_ROOT}/docs/man/man1" keystone-cli.1
 
   if command -v shasum > /dev/null 2>&1; then
-    shasum -a 256 "$ARCHIVE"
+    shasum -a 256 "${ARCHIVE}"
   else
-    sha256sum "$ARCHIVE"
+    sha256sum "${ARCHIVE}"
   fi
 }
 
-if [[ -n "$RID" ]]; then
-  package "$RID"
+if [[ -n "${RID}" ]]; then
+  package "${RID}"
 else
   package osx-arm64
   package osx-x64
@@ -159,4 +159,4 @@ else
   package linux-arm64
 fi
 
-echo "Done."
+echo "OK"

--- a/scripts/validate-arch.sh
+++ b/scripts/validate-arch.sh
@@ -21,12 +21,12 @@ fi
 
 ARCH="$1"
 
-case "$ARCH" in
+case "${ARCH}" in
   amd64 | arm64)
-    echo "$ARCH"
+    echo "${ARCH}"
     ;;
   *)
-    echo "ERROR: Invalid architecture: $ARCH" >&2
+    echo "ERROR: Invalid architecture: ${ARCH}" >&2
     echo "Supported architectures: amd64, arm64" >&2
     exit 1
     ;;

--- a/scripts/validate-rid.sh
+++ b/scripts/validate-rid.sh
@@ -33,24 +33,24 @@ fi
 
 RID="$1"
 
-if [[ "$LINUX_ONLY" == true ]]; then
-  case "$RID" in
+if [[ "${LINUX_ONLY}" == true ]]; then
+  case "${RID}" in
     linux-x64 | linux-arm64)
-      echo "$RID"
+      echo "${RID}"
       ;;
     *)
-      echo "ERROR: Invalid Linux RID: $RID" >&2
+      echo "ERROR: Invalid Linux RID: ${RID}" >&2
       echo "Supported Linux RIDs: linux-x64, linux-arm64" >&2
       exit 1
       ;;
   esac
 else
-  case "$RID" in
+  case "${RID}" in
     osx-arm64 | osx-x64 | linux-x64 | linux-arm64)
-      echo "$RID"
+      echo "${RID}"
       ;;
     *)
-      echo "ERROR: Invalid RID: $RID" >&2
+      echo "ERROR: Invalid RID: ${RID}" >&2
       echo "Supported RIDs: osx-arm64, osx-x64, linux-x64, linux-arm64" >&2
       exit 1
       ;;

--- a/scripts/validate-version.sh
+++ b/scripts/validate-version.sh
@@ -24,10 +24,10 @@ VERSION="$1"
 
 # Semver pattern: MAJOR.MINOR.PATCH with optional -prerelease.identifier
 # Allows: 1.0.0, 0.2.0, 1.0.0-beta.1, 2.0.0-rc.1, 1.0.0-alpha
-if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$ ]]; then
-  echo "ERROR: Invalid version format: $VERSION" >&2
+if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$ ]]; then
+  echo "ERROR: Invalid version format: ${VERSION}" >&2
   echo "Expected: MAJOR.MINOR.PATCH (e.g., 1.0.0) or MAJOR.MINOR.PATCH-prerelease (e.g., 1.0.0-beta.1)" >&2
   exit 1
 fi
 
-echo "$VERSION"
+echo "${VERSION}"

--- a/scripts/verify-deb-install.sh
+++ b/scripts/verify-deb-install.sh
@@ -23,43 +23,41 @@ fi
 
 DEB_FILE="$1"
 
-if [[ ! -f "$DEB_FILE" ]]; then
-  echo "ERROR: File not found: $DEB_FILE"
+if [[ ! -f "${DEB_FILE}" ]]; then
+  echo "ERROR: File not found: ${DEB_FILE}" >&2
   exit 1
 fi
 
-echo "=== Installing dependencies ==="
-apt-get update
-apt-get install -y man-db
+# Install the package (dependencies are declared in the .deb)
+apt-get update -qq > /dev/null
+apt-get install -y -qq man-db > /dev/null
+apt-get install -y -qq "${DEB_FILE}" > /dev/null
 
-echo ""
-echo "=== Installing package: $DEB_FILE ==="
-apt-get install -y "$DEB_FILE"
+# Verify
+echo -n "Binary exists at /opt/keystone-cli/keystone-cli..." \
+  && test -x /opt/keystone-cli/keystone-cli \
+  && echo " OK"
 
-echo ""
-echo "=== Verifying installation ==="
-which keystone-cli
-ls -la /opt/keystone-cli/
-ls -la /usr/local/bin/keystone-cli
+echo -n "Symlink exists at /usr/local/bin/keystone-cli..." \
+  && test -L /usr/local/bin/keystone-cli \
+  && echo " OK"
 
-echo ""
-echo "=== Running keystone-cli info ==="
-keystone-cli info
+echo -n "keystone-cli --version..." \
+  && keystone-cli --version > /dev/null \
+  && echo " OK"
 
-echo ""
-echo "=== Checking man page ==="
-man -w keystone-cli
+echo -n "keystone-cli info..." \
+  && keystone-cli info > /dev/null \
+  && echo " OK"
 
-echo ""
-echo "=== Version check ==="
-keystone-cli --version
+echo -n "man -w keystone-cli..." \
+  && man -w keystone-cli > /dev/null \
+  && echo " OK"
 
-echo ""
-echo "=== Checking shell completions ==="
-ls -la /usr/share/bash-completion/completions/keystone-cli
-ls -la /usr/share/zsh/vendor-completions/_keystone-cli
+echo -n "Bash completion exists..." \
+  && test -f /usr/share/bash-completion/completions/keystone-cli \
+  && echo " OK"
 
-echo ""
-echo "==========================================="
-echo "SUCCESS: Package verified"
-echo "==========================================="
+echo -n "Zsh completion exists..." \
+  && test -f /usr/share/zsh/vendor-completions/_keystone-cli \
+  && echo " OK"

--- a/tests/deb/test-package.sh
+++ b/tests/deb/test-package.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 #
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $0 <path-to-deb> [image]"
@@ -40,20 +40,19 @@ fi
 DEB_FILE="$1"
 IMAGE="${2:-debian:bookworm-slim}"
 
-if [[ ! -f "$DEB_FILE" ]]; then
-  echo "ERROR: File not found: $DEB_FILE"
+if [[ ! -f "${DEB_FILE}" ]]; then
+  echo "ERROR: File not found: ${DEB_FILE}" >&2
   exit 1
 fi
 
-DEB_DIR="$(cd "$(dirname "$DEB_FILE")" && pwd)"
-DEB_FILENAME=$(basename "$DEB_FILE")
+DEB_DIR="$(cd "$(dirname "${DEB_FILE}")" && pwd)"
+DEB_FILENAME="$(basename "${DEB_FILE}")"
 
-echo "Testing .deb package: $DEB_FILE"
-echo "Image: $IMAGE"
-echo "==========================================="
+echo "Testing .deb package: ${DEB_FILE}"
+echo "Image: ${IMAGE}"
 
 docker run --rm \
-  -v "$DEB_DIR:/deb:ro" \
-  -v "$REPO_ROOT/scripts:/scripts:ro" \
-  "$IMAGE" \
-  bash /scripts/verify-deb-install.sh "/deb/$DEB_FILENAME"
+  -v "${DEB_DIR}:/deb:ro" \
+  -v "${REPO_ROOT}/scripts:/scripts:ro" \
+  "${IMAGE}" \
+  bash /scripts/verify-deb-install.sh "/deb/${DEB_FILENAME}"


### PR DESCRIPTION
## Summary

Adopt the same concise Linux-style output pattern used in devops across all shell scripts. Verbose banners and raw command output are replaced with structured check/OK lines in verification scripts, and quieter messaging in build/test scripts. Also enforces `require-variable-braces` (SC2250) by lowering shellcheck severity from `warning` to `style`.

## Related Issues

Fixes #158

## Changes

- Refactor `verify-deb-install.sh` to use `echo -n "check..." && command > /dev/null && echo " OK"` pattern
- Adopt concise messaging in `test-all.sh` and `test-package.sh` to match devops equivalents
- Lower shellcheck severity to `style` in Makefile so SC2250 is enforced
- Brace all variable references (`$VAR` → `${VAR}`) across 10 scripts
- Simplify markdownlint glob to a single `**/*.md` pattern
- Invoke `test-all.sh` directly instead of via `bash`