### PR TITLE
Remove redundant bash prefixes and shell directives

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -58,7 +58,7 @@ runs:
         if [[ -f "artifacts/completions/keystone-cli.bash" ]]; then
           echo "Completion scripts already exist, skipping generation"
         else
-          bash ./scripts/generate-completions.sh "$(find artifacts/bin -name keystone-cli -path "*/${RID}/publish/*")" artifacts/completions
+          ./scripts/generate-completions.sh "$(find artifacts/bin -name keystone-cli -path "*/${RID}/publish/*")" artifacts/completions
         fi
 
     - name: Build .deb package
@@ -68,7 +68,7 @@ runs:
         RID: ${{ inputs.rid }}
       run: |
         if [[ -n "$VERSION" ]]; then
-          bash ./scripts/package-deb.sh "$VERSION" "$RID"
+          ./scripts/package-deb.sh "$VERSION" "$RID"
         else
-          bash ./scripts/package-deb.sh "$RID"
+          ./scripts/package-deb.sh "$RID"
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,4 +147,4 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: |
           SAFE_ARCH="$(./scripts/validate-arch.sh "${ARCH}")"
-          bash ./scripts/verify-deb-install.sh ./deb/keystone-cli_*_"${SAFE_ARCH}".deb
+          ./scripts/verify-deb-install.sh ./deb/keystone-cli_*_"${SAFE_ARCH}".deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,10 @@ jobs:
 
       - name: Extract version from tag
         id: v
-        shell: bash
         run: |
           echo "version=${GITHUB_REF_NAME#v}" >> "${GITHUB_OUTPUT}"
 
       - name: Validate csproj version matches tag
-        shell: bash
         env:
           TAG_VERSION: ${{ steps.v.outputs.version }}
         run: |
@@ -48,7 +46,7 @@ jobs:
         run: dotnet publish ./src/Keystone.Cli/Keystone.Cli.csproj -c Release -r linux-x64
 
       - name: Generate shell completion scripts
-        run: bash ./scripts/generate-completions.sh "$(find artifacts/bin -name keystone-cli -path '*/linux-x64/publish/*')" artifacts/completions
+        run: ./scripts/generate-completions.sh "$(find artifacts/bin -name keystone-cli -path '*/linux-x64/publish/*')" artifacts/completions
 
       - name: Upload completions artifact
         uses: actions/upload-artifact@v6
@@ -98,11 +96,10 @@ jobs:
         run: dotnet publish ./src/Keystone.Cli/Keystone.Cli.csproj -c Release -r "${RID}"
 
       - name: Package tarball (${{ matrix.rid }})
-        shell: bash
         env:
           VERSION: ${{ needs.validate.outputs.version }}
           RID: ${{ matrix.rid }}
-        run: bash ./scripts/package-release.sh "${VERSION}" "${RID}"
+        run: ./scripts/package-release.sh "${VERSION}" "${RID}"
 
       - name: Upload tarball artifact
         uses: actions/upload-artifact@v6
@@ -162,7 +159,7 @@ jobs:
         env:
           VERSION: ${{ needs.validate.outputs.version }}
           ARCH: ${{ matrix.arch }}
-        run: bash ./scripts/verify-deb-install.sh "./deb/keystone-cli_${VERSION}_${ARCH}.deb"
+        run: ./scripts/verify-deb-install.sh "./deb/keystone-cli_${VERSION}_${ARCH}.deb"
 
   publish-release:
     name: Publish Release
@@ -182,7 +179,7 @@ jobs:
           path: dist
 
       - name: Generate checksums and release body
-        run: bash ./scripts/generate-checksums.sh dist
+        run: ./scripts/generate-checksums.sh dist
 
       - name: Create GitHub Release and upload assets
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -18,27 +18,23 @@ jobs:
       - uses: ./.github/actions/setup-dotnet
 
       - name: Add github.com to known_hosts
-        shell: bash
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan -H github.com >> ~/.ssh/known_hosts
 
       - name: Ensure origin uses SSH
-        shell: bash
         run: |
           git remote set-url origin git@github.com:Knight-Owl-Dev/keystone-cli.git
           git remote -v
 
       - name: Read version from csproj
         id: v
-        shell: bash
         run: echo "version=$(./scripts/get-version.sh)" >> "${GITHUB_OUTPUT}"
 
       - name: Run unit tests (gate tagging)
         run: dotnet test ./tests/Keystone.Cli.UnitTests/Keystone.Cli.UnitTests.csproj -c Release
 
       - name: Ensure tag does not already exist
-        shell: bash
         env:
           VERSION: ${{ steps.v.outputs.version }}
         run: |
@@ -49,7 +45,6 @@ jobs:
           fi
 
       - name: Create and push tag
-        shell: bash
         env:
           VERSION: ${{ steps.v.outputs.version }}
         run: |

--- a/docs/how-to/how-to-security.md
+++ b/docs/how-to/how-to-security.md
@@ -22,7 +22,6 @@ to script injection if the value contains shell metacharacters.
 
 ```yaml
 - name: Validate csproj version matches tag
-  shell: bash
   env:
     TAG_VERSION: ${{ steps.v.outputs.version }}
   run: |
@@ -154,7 +153,7 @@ esac
 
 ```bash
 SAFE_ARCH="$(./scripts/validate-arch.sh "$ARCH")"
-bash ./scripts/verify-deb-install.sh ./deb/keystone-cli_*_"$SAFE_ARCH".deb
+./scripts/verify-deb-install.sh ./deb/keystone-cli_*_"$SAFE_ARCH".deb
 ```
 
 ### Safe Variable Quoting
@@ -174,7 +173,7 @@ comment explaining why.
 ```bash
 # SAFE_ARCH is the validated architecture;
 # * is left unquoted for globbing and "$SAFE_ARCH" is quoted after the glob.
-bash ./scripts/verify-deb-install.sh ./deb/keystone-cli_*_"$SAFE_ARCH".deb
+./scripts/verify-deb-install.sh ./deb/keystone-cli_*_"$SAFE_ARCH".deb
 ```
 
 ### Defense in Depth

--- a/tests/deb/test-package.sh
+++ b/tests/deb/test-package.sh
@@ -55,4 +55,4 @@ docker run --rm \
   -v "${DEB_DIR}:/deb:ro" \
   -v "${REPO_ROOT}/scripts:/scripts:ro" \
   "${IMAGE}" \
-  bash /scripts/verify-deb-install.sh "/deb/${DEB_FILENAME}"
+  /scripts/verify-deb-install.sh "/deb/${DEB_FILENAME}"


### PR DESCRIPTION
## Summary

Every script in the repository has a proper `#!/usr/bin/env bash` shebang and executable permissions, but invocations were inconsistent — some used `bash ./scripts/…` while others used `./scripts/…` directly. Similarly, workflow steps on Linux/macOS runners included unnecessary `shell: bash` directives. This PR removes all redundant prefixes and directives for consistency.

## Related Issues

Fixes #162

## Changes

- Remove `bash` prefix from 11 script invocations across CI workflows, composite actions, test scripts, and documentation
- Remove unnecessary `shell: bash` from 8 workflow steps in `release.yml` and `tag-release.yml` (kept in `build-deb/action.yml` where composite actions require it)