### PR TITLE
Use array for TEST_IMAGES in test-all.sh

### DIFF
--- a/tests/deb/test-all.sh
+++ b/tests/deb/test-all.sh
@@ -54,7 +54,7 @@ BUILD_TARGETS=(
 )
 
 # Test images to use
-TEST_IMAGES="debian:bookworm ubuntu:24.04"
+TEST_IMAGES=("debian:bookworm" "ubuntu:24.04")
 
 echo "Building and testing keystone-cli v${VERSION}"
 echo "Host architecture: ${HOST_ARCH} (${HOST_DEB_ARCH})"
@@ -96,7 +96,7 @@ for target in "${BUILD_TARGETS[@]}"; do
     continue
   fi
 
-  for image in ${TEST_IMAGES}; do
+  for image in "${TEST_IMAGES[@]}"; do
     echo ""
     echo "Testing ${deb_file} on ${image}..."
 


### PR DESCRIPTION
## Summary

Replace the word-split string `TEST_IMAGES` with a proper Bash array so the test image loop does not rely on implicit word splitting. This aligns with the project's strict shell scripting conventions.

Fixes #165

## Changes

- Convert `TEST_IMAGES` from a plain string to an array declaration
- Update the `for` loop to iterate with `"${TEST_IMAGES[@]}"`