### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -41,7 +41,7 @@ runs:
       run: ./scripts/validate-version.sh "$VERSION" > /dev/null
 
     - name: Setup Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: stable
         cache: false

--- a/.github/actions/setup-dotnet/action.yml
+++ b/.github/actions/setup-dotnet/action.yml
@@ -12,12 +12,12 @@ runs:
   steps:
     - name: Setup .NET SDK (from global.json)
       if: inputs.dotnet-version == ''
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
         global-json-file: global.json
 
     - name: Setup .NET SDK (from input override)
       if: inputs.dotnet-version != ''
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
         dotnet-version: ${{ inputs.dotnet-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   lint-dotnet:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-dotnet
       - name: Lint
         run: make lint-dotnet
@@ -22,14 +22,14 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/knight-owl-dev/ci-tools:latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Lint
         run: make lint SKIP="lint-dotnet"
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/setup-dotnet
 
@@ -43,9 +43,9 @@ jobs:
     outputs:
       packaging: ${{ steps.filter.outputs.packaging }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -75,7 +75,7 @@ jobs:
             rid: linux-arm64
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/setup-dotnet
 
@@ -90,7 +90,7 @@ jobs:
           rid: ${{ matrix.rid }}
 
       - name: Upload .deb artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deb-${{ matrix.rid }}
           path: artifacts/release/keystone-cli_*.deb
@@ -130,13 +130,13 @@ jobs:
 
     steps:
       - name: Checkout (for verify script)
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: scripts
           sparse-checkout-cone-mode: false
 
       - name: Download .deb artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: deb-${{ matrix.rid }}
           path: deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
         run: ./scripts/generate-completions.sh "$(find artifacts/bin -name keystone-cli -path '*/linux-x64/publish/*')" artifacts/completions
 
       - name: Upload completions artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: completions
           path: artifacts/completions/
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -85,7 +85,7 @@ jobs:
         uses: ./.github/actions/setup-dotnet
 
       - name: Download completions artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: completions
           path: artifacts/completions
@@ -102,7 +102,7 @@ jobs:
         run: ./scripts/package-release.sh "${VERSION}" "${RID}"
 
       - name: Upload tarball artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist-${{ matrix.rid }}
           path: artifacts/release/keystone-cli_${{ needs.validate.outputs.version }}_${{ matrix.rid }}.tar.gz
@@ -117,7 +117,7 @@ jobs:
 
       - name: Upload .deb artifact
         if: startsWith(matrix.rid, 'linux-')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deb-${{ matrix.rid }}
           path: artifacts/release/keystone-cli_*.deb
@@ -144,13 +144,13 @@ jobs:
 
     steps:
       - name: Checkout (for verify script)
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: scripts
           sparse-checkout-cone-mode: false
 
       - name: Download .deb artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: deb-linux-x64
           path: deb
@@ -171,10 +171,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
 
@@ -182,7 +182,7 @@ jobs:
         run: ./scripts/generate-checksums.sh dist
 
       - name: Create GitHub Release and upload assets
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: "keystone-cli v${{ needs.validate.outputs.version }}"
           generate_release_notes: true
@@ -195,7 +195,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -205,7 +205,7 @@ jobs:
             homebrew-tap
 
       - name: Trigger apt repository update
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: knight-owl-dev/apt
@@ -213,7 +213,7 @@ jobs:
           client-payload: '{"versions": "keystone-cli:${{ needs.validate.outputs.version }}"}'
 
       - name: Trigger Homebrew tap update
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: knight-owl-dev/homebrew-tap

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -10,7 +10,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # required to create/push tags reliably
           ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ lint-actionlint: ## Validate GitHub Actions workflows
 	@echo "Checking GitHub Actions workflows (actionlint)..."
 	@actionlint .github/workflows/*.yml
 	@echo "OK"
+	@echo "Validating action pins..."
+	@validate-action-pins .github/actions/**/action.yml .github/workflows/*.yml
+	@echo "OK"
 
 lint-markdown: ## Check Markdown file formatting
 	@echo "Checking Markdown files (markdownlint)..."


### PR DESCRIPTION
## Summary

Harden the supply chain for CI by pinning every external GitHub Action reference to a full commit SHA with a trailing semver comment. Tag-only refs (`@v6`) are vulnerable to tag-rewriting attacks; SHAs lock the running code to what was audited, while the version comment keeps dependabot's bump flow clean. Adds a local validator so future edits can't silently regress — each pinned SHA is checked against its claimed tag via the GitHub API.

## Related Issues

Refs #179

## Changes

- Pin all 9 external actions (`actions/checkout`, `actions/setup-dotnet`, `actions/setup-go`, `actions/upload-artifact`, `actions/download-artifact`, `actions/create-github-app-token`, `dorny/paths-filter`, `softprops/action-gh-release`, `peter-evans/repository-dispatch`) across 3 workflows and 2 composite actions
- Wire `validate-action-pins` into the `lint-actionlint` target so CI catches mismatched SHA/tag pairs

## Further Comments

`make lint-actionlint` now runs both `actionlint` and `validate-action-pins` against all workflow and composite-action YAMLs; all 13 pinned refs validate against the GitHub API.