### PR TITLE
Migrate create-github-app-token from app-id to client-id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: knight-owl-dev
           repositories: |


### PR DESCRIPTION
## Summary

Silences the `Input 'app-id' has been deprecated` warning emitted by `actions/create-github-app-token` in the release workflow. Switching to the `client-id` input that the action introduced in v3.1.0 keeps the release pipeline aligned with the upstream's supported surface, so a future major bump that drops `app-id` entirely won't break releases.

## Related Issues

Fixes #184

## Changes

- Switch `actions/create-github-app-token` in `release.yml` from `app-id: ${{ secrets.APP_ID }}` to `client-id: ${{ vars.APP_CLIENT_ID }}`

## Further Comments

- The action is already pinned to `v3.1.1` (from #185), which supports `client-id`.
- `APP_CLIENT_ID` is configured as a repo variable (Client ID is a public identifier, matching upstream convention).
- The now-unused `APP_ID` secret can be deleted after the next successful release confirms the migration.
- Tracked alongside `knight-owl-dev/devops#120`.